### PR TITLE
hybris-patches: Fix a bunch of mostly visual-only issues

### DIFF
--- a/apply-patches.sh
+++ b/apply-patches.sh
@@ -21,7 +21,7 @@ else
     MBS=$(find . -name *.patch -exec dirname {} \; |sort -u)
     for mb in $MBS; do
         cd $OLD_WD/$mb
-        git am $OLD_WD/hybris-patches/$mb/*.patch
+        git am --no-gpg-sign $OLD_WD/hybris-patches/$mb/*.patch
     done
 fi
 

--- a/bionic/0001-hybris-Fix-__get_tls-and-related-functions-Android-8.patch
+++ b/bionic/0001-hybris-Fix-__get_tls-and-related-functions-Android-8.patch
@@ -134,7 +134,7 @@ new file mode 100644
 index 000000000..4a8fa5fc2
 --- /dev/null
 +++ b/libc/private/__get_tls_internal.h
-@@ -0,0 +1,54 @@
+@@ -0,0 +1,53 @@
 +/*
 + * Copyright (C) 2008 The Android Open Source Project
 + * All rights reserved.
@@ -188,7 +188,6 @@ index 000000000..4a8fa5fc2
 +#endif
 +
 +#endif /* __BIONIC_PRIVATE_GET_TLS_INTERNAL_H_ */
-+
 -- 
 2.17.1
 

--- a/bionic/0001-hybris-Fix-__get_tls-and-related-functions-Android-8.patch
+++ b/bionic/0001-hybris-Fix-__get_tls-and-related-functions-Android-8.patch
@@ -1,7 +1,7 @@
 From 85e56a2f67750c2a7caa2e30e6e7b3fee55c485c Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jollamobile.com>
 Date: Thu, 1 Feb 2018 00:57:52 +0000
-Subject: [PATCH 1/6] (hybris) Fix __get_tls and related functions (>=Android
+Subject: [PATCH 1/8] (hybris) Fix __get_tls and related functions (>=Android
  8)
 
 Change-Id: If75e4ae739ec6c482a68b1b69c2130535add2279

--- a/bionic/0002-hybris-Add-support-for-get-and-list-of-properties.patch
+++ b/bionic/0002-hybris-Add-support-for-get-and-list-of-properties.patch
@@ -1,7 +1,7 @@
 From 4148fbbe5b2b9992f906d1938d24d2cad958aea7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Sun, 17 Dec 2017 00:16:16 +0200
-Subject: [PATCH 2/6] (hybris) Add support for get and list of properties.
+Subject: [PATCH 2/8] (hybris) Add support for get and list of properties.
 
 Change-Id: I089a2a146c06d8ad0c234f0a9a4b5aa07beaeed5
 ---

--- a/bionic/0003-hybris-bionic_tls.h-shifting-TLS-slots-to-avoid-conf.patch
+++ b/bionic/0003-hybris-bionic_tls.h-shifting-TLS-slots-to-avoid-conf.patch
@@ -1,7 +1,7 @@
 From d7dc0bc42b3980d9e0e1c35deacbba75a3e79d6a Mon Sep 17 00:00:00 2001
 From: Ricardo Salveti de Araujo <ricardo.salveti@canonical.com>
 Date: Thu, 9 Jan 2014 00:57:01 -0200
-Subject: [PATCH 3/6] (hybris) bionic_tls.h: shifting TLS slots to avoid
+Subject: [PATCH 3/8] (hybris) bionic_tls.h: shifting TLS slots to avoid
  conflicts with libc/hybris
 
 Change-Id: Idf503fe8fa0a24edf4dbbabaa8d3a1c2d1f60295

--- a/bionic/0004-hybris-disable-tls-usage-in-locale.cpp-to-avoid-prob.patch
+++ b/bionic/0004-hybris-disable-tls-usage-in-locale.cpp-to-avoid-prob.patch
@@ -1,7 +1,7 @@
 From 2f873a2821140fbcecc2fc2c780311d2c86bb0e0 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Wed, 18 Apr 2018 18:37:09 +0200
-Subject: [PATCH 4/6] (hybris) disable tls usage in locale.cpp, to avoid
+Subject: [PATCH 4/8] (hybris) disable tls usage in locale.cpp, to avoid
  problems with libhybris
 
 Change-Id: I498a9749853e6a5a4aaa4ae93479aff083e02d4c

--- a/bionic/0005-hybris-Fix-TLS-slots-for-x86-Aligns-with-this-libhyb.patch
+++ b/bionic/0005-hybris-Fix-TLS-slots-for-x86-Aligns-with-this-libhyb.patch
@@ -20,7 +20,7 @@ index af4d4d07c..07590f60c 100644
 -  TLS_SLOT_ERRNO = 5,
 +
 +  TLS_SLOT_STACK_GUARD = 5, // GCC requires this specific slot for x86.
-+  
++
 +  TLS_SLOT_ERRNO,
  
    // These two aren't used by bionic itself, but allow the graphics code to

--- a/bionic/0005-hybris-Fix-TLS-slots-for-x86-Aligns-with-this-libhyb.patch
+++ b/bionic/0005-hybris-Fix-TLS-slots-for-x86-Aligns-with-this-libhyb.patch
@@ -1,7 +1,7 @@
 From 9c38126cb2cc4f894cc1fb22261924359c962c32 Mon Sep 17 00:00:00 2001
 From: Ilya Bizyaev <bizyaev@zoho.com>
 Date: Sat, 20 Jan 2018 17:48:27 +0300
-Subject: [PATCH 5/6] (hybris) Fix TLS slots for x86 Aligns with this libhybris
+Subject: [PATCH 5/8] (hybris) Fix TLS slots for x86 Aligns with this libhybris
  patch: https://github.com/libhybris/libhybris/pull/370
 
 Change-Id: Ibdbfa1c1672cbac5a687afdedbb1d8ff05861f4f

--- a/bionic/0006-hybris-don-t-fail-because-of-fsetxattr.patch
+++ b/bionic/0006-hybris-don-t-fail-because-of-fsetxattr.patch
@@ -1,7 +1,7 @@
 From 0f1be111b01e50e849448f113c6110ad3841fa82 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <f_haider@gmx.at>
 Date: Thu, 28 Mar 2019 13:10:48 -0400
-Subject: [PATCH 6/6] (hybris) don't fail because of fsetxattr
+Subject: [PATCH 6/8] (hybris) don't fail because of fsetxattr
 
 Change-Id: I4d765ff401d6b4f12da0305416cb751eb0c9e96b
 ---

--- a/bionic/0007-halium-libdl-neutralize-cfi_slowpath_common-as-it-br.patch
+++ b/bionic/0007-halium-libdl-neutralize-cfi_slowpath_common-as-it-br.patch
@@ -1,7 +1,7 @@
 From b523d4c4be73ed7f3846b28b98ced6d1ae325d13 Mon Sep 17 00:00:00 2001
 From: NeKit <nekit1000@gmail.com>
 Date: Fri, 3 Jul 2020 20:10:20 +0200
-Subject: [PATCH 7/7] (halium) libdl: neutralize cfi_slowpath_common as it
+Subject: [PATCH 7/8] (halium) libdl: neutralize cfi_slowpath_common as it
  breaks libhybris
 
 Change-Id: I90b4af9d9e6b23cccafb659931a8e85b8bae091a

--- a/build/make/0001-hybris-rename-dbus-group-to-adbus-to-avoid-conflicts.patch
+++ b/build/make/0001-hybris-rename-dbus-group-to-adbus-to-avoid-conflicts.patch
@@ -1,7 +1,7 @@
 From c353bc17e0f90b3171cafafd153d016b22f3f067 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Thu, 30 Aug 2018 14:42:07 +0200
-Subject: [PATCH 1/3] (hybris) rename dbus group to adbus to avoid conflicts
+Subject: [PATCH 1/5] (hybris) rename dbus group to adbus to avoid conflicts
  with mer.
 
 ---

--- a/build/make/0002-hybris-build-minimization-might-be-improveable-but-t.patch
+++ b/build/make/0002-hybris-build-minimization-might-be-improveable-but-t.patch
@@ -1,7 +1,7 @@
 From 7f4bafbef13272a5c691c6e2ea0855e4790f5464 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Thu, 7 Jun 2018 15:32:40 +0000
-Subject: [PATCH 2/3] (hybris) build minimization (might be improveable, but
+Subject: [PATCH 2/5] (hybris) build minimization (might be improveable, but
  this version doesn't break dependancies)
 
 Change-Id: Ic862dc084f5f4e3fa7ccd90b0757deff0f17b802

--- a/build/make/0003-hybris-Reduce-vendorimage-build-size.patch
+++ b/build/make/0003-hybris-Reduce-vendorimage-build-size.patch
@@ -1,7 +1,7 @@
 From c8e2442ae48213e41c9df28f02db69fbb687c8ac Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Fri, 22 Mar 2019 18:36:56 +0200
-Subject: [PATCH 3/3] (hybris) Reduce vendorimage build size.
+Subject: [PATCH 3/5] (hybris) Reduce vendorimage build size.
 
 Change-Id: Id025a7d7c81cb19c2881ff6619084b638ce983fb
 ---

--- a/build/make/0005-halium-vndk-depend-on-32-bit-libraries-as-well.patch
+++ b/build/make/0005-halium-vndk-depend-on-32-bit-libraries-as-well.patch
@@ -1,7 +1,7 @@
 From de3fa3e5f446b52a4420235b0722257e297b62f5 Mon Sep 17 00:00:00 2001
 From: NeKit <nekit1000@gmail.com>
 Date: Tue, 24 Mar 2020 15:39:09 +0100
-Subject: [PATCH] (halium) vndk: depend on 32-bit libraries as well
+Subject: [PATCH 5/5] (halium) vndk: depend on 32-bit libraries as well
 
 Change-Id: Ie84e4e8ff034468e28e0d77b478d39df8d3a8125
 ---

--- a/frameworks/av/0001-hybris-AudioService-is-disabled-in-hybris-adaptation.patch
+++ b/frameworks/av/0001-hybris-AudioService-is-disabled-in-hybris-adaptation.patch
@@ -1,7 +1,7 @@
 From ce2a3fe462eccac207fd0301194e6b82c9c398e3 Mon Sep 17 00:00:00 2001
 From: Alfred Neumayer <dev.beidl@gmail.com>
 Date: Mon, 30 Mar 2020 13:35:58 +0000
-Subject: [PATCH] (hybris) AudioService is disabled in hybris adaptations
+Subject: [PATCH 1/4] (hybris) AudioService is disabled in hybris adaptations
 
 Without this patch, camera is waiting for AudioService indefinitely
 

--- a/frameworks/av/0002-halium-disable-media-related-services.patch
+++ b/frameworks/av/0002-halium-disable-media-related-services.patch
@@ -1,7 +1,7 @@
 From 322b203ffc1fb8d7f15f56111debce0dd57c752c Mon Sep 17 00:00:00 2001
 From: NeKit <nekit1000@gmail.com>
 Date: Sun, 9 Feb 2020 18:39:54 +0100
-Subject: [PATCH 2/2] (halium) disable media-related services
+Subject: [PATCH 2/4] (halium) disable media-related services
 
 Their functionality is provided by minimedia in droidmedia repo instead
 

--- a/frameworks/av/0003-Rely-on-local-codec-list-only-we-do-not-run-media.pl.patch
+++ b/frameworks/av/0003-Rely-on-local-codec-list-only-we-do-not-run-media.pl.patch
@@ -1,7 +1,7 @@
 From 4ea8a6e2297bb3dbe21bd2aad4def65ec609c84b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Thomas=20Vo=C3=9F?= <thomas.voss.bochum@gmail.com>
 Date: Wed, 3 Feb 2016 17:46:38 +0100
-Subject: [PATCH] Rely on local codec list only, we do not run
+Subject: [PATCH 3/4] (halium) Rely on local codec list only, we do not run
  media.player/service.
 
 Signed-off-by: Ondrej Kubik <ondrej.kubik@canonical.com>

--- a/frameworks/native/0001-hybris-Use-mini-services-and-disable-starting-unneed.patch
+++ b/frameworks/native/0001-hybris-Use-mini-services-and-disable-starting-unneed.patch
@@ -1,7 +1,7 @@
 From 350edde725c9c399b594533ae071681befb82cd5 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Thu, 13 Jul 2017 00:53:55 +0300
-Subject: [PATCH 1/6] (hybris) Use mini services and disable starting unneeded
+Subject: [PATCH 1/9] (hybris) Use mini services and disable starting unneeded
  services.
 
 Change-Id: I6e80eb3e2d92ddfbd83f1933971c3f24e9570d28

--- a/frameworks/native/0002-hybris-Pick-GLES-shared-objects-from-appropriate-pat.patch
+++ b/frameworks/native/0002-hybris-Pick-GLES-shared-objects-from-appropriate-pat.patch
@@ -1,7 +1,7 @@
 From db0ea858d3b172aa43ba535b8165cc52dca28a50 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Wed, 15 Jul 2015 08:29:08 +0000
-Subject: [PATCH 2/6] (hybris) Pick GLES shared objects from appropriate paths
+Subject: [PATCH 2/9] (hybris) Pick GLES shared objects from appropriate paths
  (32-bit case)
 
 Change-Id: I4c7739ba8a4d64fa115163d5700b0df3370b286b

--- a/frameworks/native/0003-hybris-Use-private-__get_tls_hooks-from-bionic.patch
+++ b/frameworks/native/0003-hybris-Use-private-__get_tls_hooks-from-bionic.patch
@@ -1,7 +1,7 @@
 From a6d1bac1aa416f2201ea57104ee4c560b2325b8f Mon Sep 17 00:00:00 2001
 From: David Greaves <david.greaves@jollamobile.com>
 Date: Tue, 25 Nov 2014 14:55:27 +0100
-Subject: [PATCH 3/6] (hybris) Use private __get_tls_hooks from bionic
+Subject: [PATCH 3/9] (hybris) Use private __get_tls_hooks from bionic
 
 Change-Id: I38a4ea6d8561ab7da5dfedeeba16b84ee493051e
 Signed-off-by: David Greaves <david.greaves@jollamobile.com>

--- a/frameworks/native/0004-hybris-Allow-surfaceflinger-to-be-started-from-Sailf.patch
+++ b/frameworks/native/0004-hybris-Allow-surfaceflinger-to-be-started-from-Sailf.patch
@@ -1,7 +1,7 @@
 From f10d668a4b23bad9144370730c84b583bebc20e8 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Wed, 18 Apr 2018 19:00:03 +0200
-Subject: [PATCH 4/6] (hybris) Allow surfaceflinger to be started from
+Subject: [PATCH 4/9] (hybris) Allow surfaceflinger to be started from
  SailfishOS.
 
 Change-Id: Ibaecd8d27524bbb0d3bc7b40017bf92736b8629d

--- a/frameworks/native/0005-hybris-Create-the-somehow-missing-settingsd-socket-f.patch
+++ b/frameworks/native/0005-hybris-Create-the-somehow-missing-settingsd-socket-f.patch
@@ -1,7 +1,7 @@
 From da58625677d57126fbe52a7c315aa2b0dae8f1d1 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Sun, 16 Jun 2019 13:14:30 +0200
-Subject: [PATCH 5/6] (hybris) Create the (somehow) missing settingsd socket
+Subject: [PATCH 5/9] (hybris) Create the (somehow) missing settingsd socket
  for rild
 
 Change-Id: Ic7415aab65788f37ee5c5a67be1916319e484f77

--- a/frameworks/native/0006-hybris-use-libselinux_stubs-in-servicemanager.patch
+++ b/frameworks/native/0006-hybris-use-libselinux_stubs-in-servicemanager.patch
@@ -1,7 +1,7 @@
 From 28f6a85f72a532946b3ad64c5f316f23c770706c Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Fri, 8 Jun 2018 14:44:30 +0200
-Subject: [PATCH 6/6] (hybris) use libselinux_stubs in servicemanager
+Subject: [PATCH 6/9] (hybris) use libselinux_stubs in servicemanager
 
 Change-Id: Iad17a5ff109e231237d7c0ed692a2dc178c99a5e
 ---

--- a/frameworks/native/0007-halium-remove-usr-libexec-droid-hybris-from-paths.patch
+++ b/frameworks/native/0007-halium-remove-usr-libexec-droid-hybris-from-paths.patch
@@ -1,7 +1,7 @@
 From ac1111ae6afe907a68c1f7be3e06efe1547793c3 Mon Sep 17 00:00:00 2001
 From: NeKit <nekit1000@gmail.com>
 Date: Sun, 9 Feb 2020 18:08:14 +0100
-Subject: [PATCH 7/7] (halium) remove /usr/libexec/droid-hybris from paths
+Subject: [PATCH 7/9] (halium) remove /usr/libexec/droid-hybris from paths
 
 Halium builds minified systemimage, so no need for overlaying
 

--- a/frameworks/native/0008-halium-include-vndservicemanager-into-system-partiti.patch
+++ b/frameworks/native/0008-halium-include-vndservicemanager-into-system-partiti.patch
@@ -1,7 +1,7 @@
 From 87adc861590c7546a176fe0f665c52f4bd82d8b3 Mon Sep 17 00:00:00 2001
 From: NeKit <nekit1000@gmail.com>
 Date: Sun, 9 Feb 2020 20:13:50 +0100
-Subject: [PATCH 8/8] (halium) include vndservicemanager into system partition
+Subject: [PATCH 8/9] (halium) include vndservicemanager into system partition
  to override service
 
 Change-Id: Ia77e6be009a4410aa8a05351a192e9d4dfe22c87

--- a/frameworks/native/0009-halium-binder-don-t-use-android-s-check-permission-f.patch
+++ b/frameworks/native/0009-halium-binder-don-t-use-android-s-check-permission-f.patch
@@ -1,7 +1,8 @@
 From cab1247927e2af0269ee3f3fd5523574822fbec5 Mon Sep 17 00:00:00 2001
 From: Ricardo Salveti de Araujo <ricardo.salveti@canonical.com>
 Date: Mon, 26 Nov 2012 15:02:39 -0200
-Subject: [PATCH] (halium) binder: don't use android's check permission feature
+Subject: [PATCH 9/9] (halium) binder: don't use android's check permission
+ feature
 
 Change-Id: I70946811c0af9899c46b4217f662bb41503b36e8
 Signed-off-by: Ricardo Salveti de Araujo <ricardo.salveti@canonical.com>

--- a/system/core/0001-hybris-Add-usr-libexec-droid-hybris-lib-dev-alog-to-.patch
+++ b/system/core/0001-hybris-Add-usr-libexec-droid-hybris-lib-dev-alog-to-.patch
@@ -1,7 +1,7 @@
 From 1477031466c0bc447e48201914ba054237a98427 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Wed, 6 Nov 2013 21:09:30 +0000
-Subject: [PATCH 01/39] (hybris) Add /usr/libexec/droid-hybris/lib-dev-alog/ to
+Subject: [PATCH 01/44] (hybris) Add /usr/libexec/droid-hybris/lib-dev-alog/ to
  the LD_LIBRARY_PATH for all init'ed binaries to support the /dev/alog used in
  Mer
 

--- a/system/core/0002-hybris-Don-t-create-mount-dev-proc-sys.-when-booting.patch
+++ b/system/core/0002-hybris-Don-t-create-mount-dev-proc-sys.-when-booting.patch
@@ -1,7 +1,7 @@
 From b422706d9a7ad022f177a464c8037e088db0a8a1 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 8 Oct 2013 16:59:30 +0100
-Subject: [PATCH 02/39] (hybris) Don't create/mount dev/proc/sys... when
+Subject: [PATCH 02/44] (hybris) Don't create/mount dev/proc/sys... when
  booting with Mer
 
 Change-Id: I16afd5bf56ee3e36f09b3496b80e356ce9269a64

--- a/system/core/0003-hybris-Mer-can-specify-mis-alignment-handling-this-i.patch
+++ b/system/core/0003-hybris-Mer-can-specify-mis-alignment-handling-this-i.patch
@@ -1,7 +1,7 @@
 From f1042f1347d6b25674f4e121c093b8e06c2e596a Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 22 Oct 2013 17:07:56 +0100
-Subject: [PATCH 03/39] (hybris) Mer can specify mis-alignment handling - this
+Subject: [PATCH 03/44] (hybris) Mer can specify mis-alignment handling - this
  is the wrong place to set it
 
 Change-Id: Ib46c0a0b6d285dbcd05736e7ba9e9fd0a0480984

--- a/system/core/0004-hybris-Mount-points-are-handled-by-Mer.patch
+++ b/system/core/0004-hybris-Mount-points-are-handled-by-Mer.patch
@@ -1,7 +1,7 @@
 From d64f7020d3ddeda18d1db6e7610d7d046d675b13 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 22 Oct 2013 17:09:20 +0100
-Subject: [PATCH 04/39] (hybris) Mount points are handled by Mer
+Subject: [PATCH 04/44] (hybris) Mount points are handled by Mer
 
 Change-Id: I295b30a47b6e147b037275032a00b304085fe711
 ---

--- a/system/core/0005-hybris-Systemd-handles-control-groups.patch
+++ b/system/core/0005-hybris-Systemd-handles-control-groups.patch
@@ -1,7 +1,7 @@
 From d5aa68ed1a6389211abd43df9e2c2109aabded31 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 22 Oct 2013 17:10:16 +0100
-Subject: [PATCH 05/39] (hybris) Systemd handles control groups
+Subject: [PATCH 05/44] (hybris) Systemd handles control groups
 
 Change-Id: I92ef4b2389544906be32169c57176575eb1719ec
 ---

--- a/system/core/0006-hybris-Mer-uses-udev.patch
+++ b/system/core/0006-hybris-Mer-uses-udev.patch
@@ -1,7 +1,7 @@
 From 155e2d07aa0832b325f8f87300c97ef2128dde67 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 22 Oct 2013 17:12:18 +0100
-Subject: [PATCH 06/39] (hybris) Mer uses udev
+Subject: [PATCH 06/44] (hybris) Mer uses udev
 
 Change-Id: I7588a80db2c77879fb56d5decfd055224f20ab54
 ---

--- a/system/core/0007-hybris-Add-a-ready-trigger-to-init-to-run-post-boot.patch
+++ b/system/core/0007-hybris-Add-a-ready-trigger-to-init-to-run-post-boot.patch
@@ -1,7 +1,7 @@
 From 5989860da7fbfb203719a06e28353fc6208ee772 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Wed, 20 Nov 2013 19:18:51 +0000
-Subject: [PATCH 07/39] (hybris) Add a ready trigger to init to run post boot
+Subject: [PATCH 07/44] (hybris) Add a ready trigger to init to run post boot
 
 Change-Id: I9c828463424c0e82c3de0159db08299e7ce6fe06
 ---

--- a/system/core/0008-hybris-Notify-Mer-s-systemd-that-we-re-done.patch
+++ b/system/core/0008-hybris-Notify-Mer-s-systemd-that-we-re-done.patch
@@ -13,7 +13,7 @@ diff --git a/rootdir/init.rc b/rootdir/init.rc
 index 5bed0e34b..7cb3685c0 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
-@@ -764,3 +764,13 @@ service flash_recovery /system/bin/install-recovery.sh
+@@ -764,3 +764,12 @@ service flash_recovery /system/bin/install-recovery.sh
  on property:persist.sys.recovery_update=true
      start flash_recovery
  
@@ -26,7 +26,6 @@ index 5bed0e34b..7cb3685c0 100644
 +service droid_init_done /bin/sh /usr/bin/droid/droid-init-done.sh
 +    class mer
 +    oneshot
-+
 -- 
 2.17.1
 

--- a/system/core/0008-hybris-Notify-Mer-s-systemd-that-we-re-done.patch
+++ b/system/core/0008-hybris-Notify-Mer-s-systemd-that-we-re-done.patch
@@ -1,7 +1,7 @@
 From 1849c79f3e1a1c90ee9b40e485725c77adf6a9c4 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Wed, 20 Nov 2013 19:24:31 +0000
-Subject: [PATCH 08/39] (hybris) Notify Mer's systemd that we're done
+Subject: [PATCH 08/44] (hybris) Notify Mer's systemd that we're done
 
 Change-Id: If6a16f43397f00c8e579af79ae6cf8459786e7b3
 Signed-off-by: David Greaves <david.greaves@jollamobile.com>

--- a/system/core/0009-hybris-Disable-usb-import.patch
+++ b/system/core/0009-hybris-Disable-usb-import.patch
@@ -1,7 +1,7 @@
 From 1adafb228c8d3e97c1b1a872b5972bbc476e7e91 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Wed, 19 Feb 2014 19:02:32 +0000
-Subject: [PATCH 09/39] (hybris) Disable usb import
+Subject: [PATCH 09/44] (hybris) Disable usb import
 
 Change-Id: I8aba60bc79fb4aab3854f0569b325ad69c5126d4
 Signed-off-by: David Greaves <david@dgreaves.com>

--- a/system/core/0010-hybris-allow-system-group-to-trigger-haptics.patch
+++ b/system/core/0010-hybris-allow-system-group-to-trigger-haptics.patch
@@ -1,7 +1,7 @@
 From 1ac7333536d0727b34e02fdc1899d62c8b28fdc0 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Thu, 13 Mar 2014 08:51:53 +0000
-Subject: [PATCH 10/39] (hybris) allow system group to trigger haptics
+Subject: [PATCH 10/44] (hybris) allow system group to trigger haptics
 
 Signed-off-by: Simonas Leleiva <simonas.leleiva@jollamobile.com>
 

--- a/system/core/0011-hybris-trigger-late_start-on-property-change.patch
+++ b/system/core/0011-hybris-trigger-late_start-on-property-change.patch
@@ -1,7 +1,7 @@
 From a2c9dd20ff97155006ca2bd4e2b06ea51d2d60aa Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Tue, 18 Mar 2014 14:07:11 +0000
-Subject: [PATCH 11/39] (hybris) trigger late_start on property change
+Subject: [PATCH 11/44] (hybris) trigger late_start on property change
 
 Android's late_start is triggered by mount_all, which also determines whether
 the /data partition is encrypted.

--- a/system/core/0012-hybris-property_service.c-adding-support-for-getprop.patch
+++ b/system/core/0012-hybris-property_service.c-adding-support-for-getprop.patch
@@ -1,7 +1,7 @@
 From 6e2d88cb450e05d1f77e579cb0b0e2249485d295 Mon Sep 17 00:00:00 2001
 From: Ricardo Salveti de Araujo <ricardo.salveti@canonical.com>
 Date: Thu, 31 Oct 2013 12:19:19 +0200
-Subject: [PATCH 12/39] (hybris) property_service.c: adding support for getprop
+Subject: [PATCH 12/44] (hybris) property_service.c: adding support for getprop
  and listprop
 
 Change-Id: Ie5fbdb55c48038ce8250f27500623b3b81cc5cd1

--- a/system/core/0013-hybris-reach-main-init-state.patch
+++ b/system/core/0013-hybris-reach-main-init-state.patch
@@ -1,7 +1,7 @@
 From c3a59d857892a951b870ccb4c3143004ed4a9946 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Sat, 22 Aug 2015 12:03:42 +0100
-Subject: [PATCH 13/39] (hybris) reach main init state
+Subject: [PATCH 13/44] (hybris) reach main init state
 
 Change-Id: I471f48afaebf91c92f0d2a7bd3a24c5d1fa58ecd
 ---

--- a/system/core/0014-hybris-Disable-setting-hostname-and-domainname-in-in.patch
+++ b/system/core/0014-hybris-Disable-setting-hostname-and-domainname-in-in.patch
@@ -1,7 +1,7 @@
 From 4ce1301cc8268a9d740a4619035c86dceceeb9c7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Sat, 6 Aug 2016 11:37:38 +0300
-Subject: [PATCH 14/39] (hybris) Disable setting hostname and domainname in
+Subject: [PATCH 14/44] (hybris) Disable setting hostname and domainname in
  init.rc.
 
 Change-Id: I5b9f59e80760e53636763c89f8f76f350c17b3ec

--- a/system/core/0015-hybris-Update-rootdir-for-64bit-libs.patch
+++ b/system/core/0015-hybris-Update-rootdir-for-64bit-libs.patch
@@ -1,7 +1,7 @@
 From fd87f13efe9db2fb1dcd29efb38d301eaa27be62 Mon Sep 17 00:00:00 2001
 From: Martin Ghosal <Martin.Ghosal@sky.uk>
 Date: Sat, 15 Oct 2016 15:38:47 +0100
-Subject: [PATCH 15/39] (hybris) Update rootdir for 64bit libs
+Subject: [PATCH 15/44] (hybris) Update rootdir for 64bit libs
 
 Change-Id: I593ae40da755c116bb28c96dcace863e6b30b4cc
 ---

--- a/system/core/0016-hybris-Disable-all-zygote-variations.patch
+++ b/system/core/0016-hybris-Disable-all-zygote-variations.patch
@@ -1,7 +1,7 @@
 From a08486cd09a2f222dd61032c123babe8db32ad3d Mon Sep 17 00:00:00 2001
 From: Martin Ghosal <Martin.Ghosal@sky.uk>
 Date: Sun, 8 Jan 2017 16:34:54 +0000
-Subject: [PATCH 16/39] (hybris) Disable all zygote variations
+Subject: [PATCH 16/44] (hybris) Disable all zygote variations
 
 Change-Id: Ie1ad26486f47b3bf67134db917b3c9e51536904c
 ---

--- a/system/core/0017-hybris-Disable-ueventd-service.patch
+++ b/system/core/0017-hybris-Disable-ueventd-service.patch
@@ -1,7 +1,7 @@
 From 1439cc542b25c8a45a59db6225f24c13a01f29f9 Mon Sep 17 00:00:00 2001
 From: Martin Ghosal <Martin.Ghosal@sky.uk>
 Date: Sun, 8 Jan 2017 17:16:08 +0000
-Subject: [PATCH 17/39] (hybris) Disable ueventd service
+Subject: [PATCH 17/44] (hybris) Disable ueventd service
 
 Change-Id: I8ee7b863a533f4a6ef7658ef1c1ef4bdb95d5d65
 ---

--- a/system/core/0018-hybris-Disable-SELinux.patch
+++ b/system/core/0018-hybris-Disable-SELinux.patch
@@ -1,7 +1,7 @@
 From 76b09fd6a855e9f1fa8a80c6fe7bf60a46c263a8 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Thu, 9 Feb 2017 21:48:19 +0200
-Subject: [PATCH 18/39] (hybris) Disable SELinux
+Subject: [PATCH 18/44] (hybris) Disable SELinux
 
 Change-Id: I0511b2a0de1b20996f4fb8e9f3569acb41e2cf0f
 ---

--- a/system/core/0019-hybris-Properly-handle-shutdown-from-Mer.patch
+++ b/system/core/0019-hybris-Properly-handle-shutdown-from-Mer.patch
@@ -12,10 +12,11 @@ diff --git a/rootdir/init.rc b/rootdir/init.rc
 index ae9cd7b08..28f0ca825 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
-@@ -788,3 +788,12 @@ service droid_init_done /bin/sh /usr/bin/droid/droid-init-done.sh
+@@ -787,3 +787,12 @@
+ service droid_init_done /bin/sh /usr/bin/droid/droid-init-done.sh
      class mer
      oneshot
- 
++
 +# Properly handle shutdown from Mer
 +on property:hybris.shutdown=*
 +    class_stop late_start
@@ -24,7 +25,6 @@ index ae9cd7b08..28f0ca825 100644
 +    class_stop hal
 +    class_stop early_hal
 +    class_stop core
-+
 -- 
 2.17.1
 

--- a/system/core/0019-hybris-Properly-handle-shutdown-from-Mer.patch
+++ b/system/core/0019-hybris-Properly-handle-shutdown-from-Mer.patch
@@ -1,7 +1,7 @@
 From e94d8cba8a43cb852949f386e3aed96a923afb53 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Sat, 8 Jul 2017 00:27:20 +0300
-Subject: [PATCH 19/39] (hybris) Properly handle shutdown from Mer.
+Subject: [PATCH 19/44] (hybris) Properly handle shutdown from Mer.
 
 Change-Id: I89daebb9559d38f3c639f4634c417252c7a92fe0
 ---

--- a/system/core/0020-hybris-Use-services-from-usr-libexec-droid-hybris-sy.patch
+++ b/system/core/0020-hybris-Use-services-from-usr-libexec-droid-hybris-sy.patch
@@ -1,7 +1,7 @@
 From c52e0c358eb27b2fccfab86a160f0c77e37a89e0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Thu, 9 Feb 2017 21:57:47 +0200
-Subject: [PATCH 20/39] (hybris) Use services from
+Subject: [PATCH 20/44] (hybris) Use services from
  /usr/libexec/droid-hybris/system/etc/init/.
 
 Change-Id: I6185781c2bd6a2db281201ad705394f4d6d24131

--- a/system/core/0021-hybris-Remove-LD_LIBRARY_PATH-from-init.environ.rc.patch
+++ b/system/core/0021-hybris-Remove-LD_LIBRARY_PATH-from-init.environ.rc.patch
@@ -1,7 +1,7 @@
 From d0229a40ad25575ad40f23434ed09f8eb5385458 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Tue, 17 Oct 2017 21:58:40 +0300
-Subject: [PATCH 21/39] (hybris) Remove LD_LIBRARY_PATH from init.environ.rc
+Subject: [PATCH 21/44] (hybris) Remove LD_LIBRARY_PATH from init.environ.rc
 
 Change-Id: I52a2c733f609f90b6ac31be72a4f8fe7681beac0
 ---

--- a/system/core/0022-hybris-define-32-bit-LD_LIBRARY_PATH-for-32-bit-devi.patch
+++ b/system/core/0022-hybris-define-32-bit-LD_LIBRARY_PATH-for-32-bit-devi.patch
@@ -1,7 +1,7 @@
 From bd88af2919d6f2552fa3b23bc0b9d71ebefd9514 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jollamobile.com>
 Date: Wed, 25 Oct 2017 14:14:59 +0300
-Subject: [PATCH 22/39] (hybris) define 32-bit LD_LIBRARY_PATH for 32-bit
+Subject: [PATCH 22/44] (hybris) define 32-bit LD_LIBRARY_PATH for 32-bit
  devices
 
 ---

--- a/system/core/0023-hybris-Fix-list-and-get-properties.patch
+++ b/system/core/0023-hybris-Fix-list-and-get-properties.patch
@@ -1,7 +1,7 @@
 From 2f7534c465019370db8adae00a3b147cb50a720d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Tue, 16 Jan 2018 16:18:31 +0200
-Subject: [PATCH 23/39] (hybris) Fix list and get properties.
+Subject: [PATCH 23/44] (hybris) Fix list and get properties.
 
 Change-Id: I9deb65f147e941fc5c9f91793f851440d02260e1
 ---

--- a/system/core/0024-hybris-more-SELinux-disablement.patch
+++ b/system/core/0024-hybris-more-SELinux-disablement.patch
@@ -1,7 +1,7 @@
 From ff19de6a3f841f39d22310a4ae5d04d03997d008 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Wed, 18 Apr 2018 18:49:02 +0200
-Subject: [PATCH 24/39] (hybris) more SELinux disablement
+Subject: [PATCH 24/44] (hybris) more SELinux disablement
 
 Change-Id: Ic1bc474e993f2b66ab9114e88d7ec4f718a99d5c
 Signed-off-by: Simonas Leleiva <simonas.leleiva@meramo.co.uk>

--- a/system/core/0025-hybris-don-t-try-to-mount-since-mer-handles-this.patch
+++ b/system/core/0025-hybris-don-t-try-to-mount-since-mer-handles-this.patch
@@ -1,7 +1,7 @@
 From 1f7726dfc49825657fa7786e27b2adb2f459b623 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Mon, 4 Jun 2018 10:00:13 +0200
-Subject: [PATCH 25/39] (hybris) don't try to mount since mer handles this
+Subject: [PATCH 25/44] (hybris) don't try to mount since mer handles this
 
 Change-Id: I305ac649fd199ef11a8d88d350f1fc06171bc0ba
 ---

--- a/system/core/0026-hybris-avoid-attempting-to-mount-partitions-mer-syst.patch
+++ b/system/core/0026-hybris-avoid-attempting-to-mount-partitions-mer-syst.patch
@@ -1,7 +1,7 @@
 From c385ba2020d6479dd530100925736d67ec9442c0 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Wed, 6 Jun 2018 09:28:27 +0200
-Subject: [PATCH 26/39] (hybris) avoid attempting to mount partitions,
+Subject: [PATCH 26/44] (hybris) avoid attempting to mount partitions,
  mer/systemd handles this
 
 Even partitions weren't mounted by this previously it still would produce an

--- a/system/core/0027-hybris-load-services-from-droid-hybris-as-early-as-p.patch
+++ b/system/core/0027-hybris-load-services-from-droid-hybris-as-early-as-p.patch
@@ -1,7 +1,7 @@
 From 26133bb98b735c422674c60aec13865554a03e90 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Wed, 6 Jun 2018 09:30:01 +0200
-Subject: [PATCH 27/39] (hybris) load services from droid-hybris as early as
+Subject: [PATCH 27/44] (hybris) load services from droid-hybris as early as
  possible
 
 This makes sure our service definitions are loaded first and can be used to

--- a/system/core/0028-hybris-disable-remnants-of-SELinux-which-currently-b.patch
+++ b/system/core/0028-hybris-disable-remnants-of-SELinux-which-currently-b.patch
@@ -1,7 +1,7 @@
 From 3a64af0e06c236586d0e8524704b1789c22f405c Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Wed, 6 Jun 2018 09:32:06 +0200
-Subject: [PATCH 28/39] (hybris) disable remnants of SELinux which currently
+Subject: [PATCH 28/44] (hybris) disable remnants of SELinux which currently
  break
 
 Change-Id: I252a8399c9853d993fc17d769bfbb2e4c722cfe8

--- a/system/core/0029-hybris-disable-the-usage-of-libprocessgroup-since-it.patch
+++ b/system/core/0029-hybris-disable-the-usage-of-libprocessgroup-since-it.patch
@@ -1,7 +1,7 @@
 From 0c0d6836c726ea40a3bfc40595a356e4b84b21a9 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Wed, 6 Jun 2018 09:33:03 +0200
-Subject: [PATCH 29/39] (hybris) disable the usage of libprocessgroup, since it
+Subject: [PATCH 29/44] (hybris) disable the usage of libprocessgroup, since it
  is incompatible.
 
 Change-Id: Ie37ac0dcc5cabbf33de55c148009fdfff3e90c64

--- a/system/core/0030-hybris-disable-vendor-symlink.patch
+++ b/system/core/0030-hybris-disable-vendor-symlink.patch
@@ -1,7 +1,7 @@
 From 84d69d03abe1c6f711d7551b74c03d892745f068 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Thu, 7 Jun 2018 15:29:53 +0000
-Subject: [PATCH 30/39] (hybris) disable vendor symlink
+Subject: [PATCH 30/44] (hybris) disable vendor symlink
 
 Change-Id: I26a32268e2f3af7ab0550397900f7a3ef0edfae5
 ---

--- a/system/core/0031-hybris-ignore-mount-and-mkdir-tmp-commands-entirely.patch
+++ b/system/core/0031-hybris-ignore-mount-and-mkdir-tmp-commands-entirely.patch
@@ -1,7 +1,7 @@
 From 7d4d7514ffeba53b8697a426c20118d34a241ea4 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Mon, 27 Aug 2018 11:08:12 +0000
-Subject: [PATCH 31/39] (hybris) ignore "mount" and "mkdir /tmp" commands
+Subject: [PATCH 31/44] (hybris) ignore "mount" and "mkdir /tmp" commands
  entirely.
 
 mount is usually removed during build, but if the *.rc files are on

--- a/system/core/0032-hybris-Fix-actdead-charging-animation.-MER-1949.patch
+++ b/system/core/0032-hybris-Fix-actdead-charging-animation.-MER-1949.patch
@@ -1,7 +1,7 @@
 From 71a7301555b2af4b2d457b9828174fd502e8350a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Thu, 30 Aug 2018 19:54:16 +0300
-Subject: [PATCH 32/39] (hybris) Fix actdead charging animation. MER#1949
+Subject: [PATCH 32/44] (hybris) Fix actdead charging animation. MER#1949
 
 ---
  rootdir/init.rc | 2 +-

--- a/system/core/0033-hybris-system-core-Disable-usb-config.patch
+++ b/system/core/0033-hybris-system-core-Disable-usb-config.patch
@@ -1,7 +1,7 @@
 From fb88c0afbacd9a1827979dc8b09761639281cea6 Mon Sep 17 00:00:00 2001
 From: Matti Kosola <matti.kosola@jolla.com>
 Date: Tue, 21 Feb 2017 13:13:26 +0100
-Subject: [PATCH 33/39] (hybris)[system/core] Disable usb config.
+Subject: [PATCH 33/44] (hybris)[system/core] Disable usb config.
 
 Signed-off-by: Matti Kosola <matti.kosola@jolla.com>
 ---

--- a/system/core/0034-hybris-Remove-sbin-from-droid-PATH.patch
+++ b/system/core/0034-hybris-Remove-sbin-from-droid-PATH.patch
@@ -1,7 +1,7 @@
 From 25929384dc9482df6671dc5da24c87b3fd32f1dd Mon Sep 17 00:00:00 2001
 From: Jussi Laakkonen <jussi.laakkonen@jolla.com>
 Date: Wed, 31 Jan 2018 17:12:14 +0200
-Subject: [PATCH 34/39] (hybris) Remove /sbin from droid PATH.
+Subject: [PATCH 34/44] (hybris) Remove /sbin from droid PATH.
 
 ---
  rootdir/init.environ.rc.in | 2 +-

--- a/system/core/0035-hybris-Fix-return-value-type-of-mount-command.patch
+++ b/system/core/0035-hybris-Fix-return-value-type-of-mount-command.patch
@@ -1,7 +1,7 @@
 From 216c77867e2fb723037fbd362492e09ccb02e14c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Sun, 18 Nov 2018 18:51:22 +0200
-Subject: [PATCH 35/39] (hybris) Fix return value type of mount command.
+Subject: [PATCH 35/44] (hybris) Fix return value type of mount command.
 
 Change-Id: Ib759e1be92d110863e43f13f7317372c6182a02d
 ---

--- a/system/core/0036-hybris-disable-some-more-selinux-functionality.patch
+++ b/system/core/0036-hybris-disable-some-more-selinux-functionality.patch
@@ -1,7 +1,7 @@
 From 04972b397b8a2754b9a4c0e5d91bf1c8acc312e1 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <f_haider@gmx.at>
 Date: Thu, 28 Mar 2019 12:46:12 -0400
-Subject: [PATCH 36/39] (hybris) disable some more selinux functionality.
+Subject: [PATCH 36/44] (hybris) disable some more selinux functionality.
 
 Change-Id: Ie63eb13b73d626668b32041fec4400cf2edd2fe5
 ---

--- a/system/core/0037-hybris-Disable-mnt-tmpfs-creation.patch
+++ b/system/core/0037-hybris-Disable-mnt-tmpfs-creation.patch
@@ -1,7 +1,7 @@
 From 6e99887c6e32a66b60f3de71a71702d908debc5f Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Mon, 3 Jun 2019 13:46:44 +0200
-Subject: [PATCH 37/39] (hybris) Disable /mnt tmpfs creation
+Subject: [PATCH 37/44] (hybris) Disable /mnt tmpfs creation
 
 Change-Id: I7c4fb119475adc345104f6ac5a68b578b6b2d433
 ---

--- a/system/core/0038-hybris-Disable-init_user0-which-is-not-needed-on-Mer.patch
+++ b/system/core/0038-hybris-Disable-init_user0-which-is-not-needed-on-Mer.patch
@@ -1,7 +1,7 @@
 From 8ab5e607e71ac798d0a8b2045492a55d6b273534 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@jolla.com>
 Date: Mon, 10 Dec 2018 12:11:06 +0200
-Subject: [PATCH 38/39] (hybris) Disable init_user0 which is not needed on Mer.
+Subject: [PATCH 38/44] (hybris) Disable init_user0 which is not needed on Mer.
 
 ---
  rootdir/init.rc | 3 ++-

--- a/system/core/0039-halium-Allow-libselinux_stubs.so-to-be-preloaded-int.patch
+++ b/system/core/0039-halium-Allow-libselinux_stubs.so-to-be-preloaded-int.patch
@@ -1,7 +1,7 @@
 From a178e891f30fe37edb2ec9d9a775b0f984dc9387 Mon Sep 17 00:00:00 2001
 From: NeKit <nekit1000@gmail.com>
 Date: Sun, 9 Feb 2020 18:14:34 +0100
-Subject: [PATCH 39/40] (halium) Allow libselinux_stubs.so to be preloaded into
+Subject: [PATCH 39/44] (halium) Allow libselinux_stubs.so to be preloaded into
  vendor binaries
 
 Change-Id: Ib80f858523c0a6493e22b53220f895fc200441af

--- a/system/core/0040-halium-start-ueventd-if-init-is-PID-1-as-in-LXC-cont.patch
+++ b/system/core/0040-halium-start-ueventd-if-init-is-PID-1-as-in-LXC-cont.patch
@@ -1,7 +1,7 @@
 From e41f17b9973c5a1e81f8bc490f526837ba9f2c75 Mon Sep 17 00:00:00 2001
 From: NeKit <nekit1000@gmail.com>
 Date: Sun, 9 Feb 2020 18:15:59 +0100
-Subject: [PATCH 40/40] (halium) start ueventd if init is PID 1 (as in LXC
+Subject: [PATCH 40/44] (halium) start ueventd if init is PID 1 (as in LXC
  container)
 
 Change-Id: I1fa2127138ea2fc38382bf56e6967b853efb6b23

--- a/system/core/0041-halium-init-Handle-udev-event-peaks.patch
+++ b/system/core/0041-halium-init-Handle-udev-event-peaks.patch
@@ -1,7 +1,7 @@
 From 90412233ac76d266b57e12c5b5a680c5683e166a Mon Sep 17 00:00:00 2001
 From: Alfonso Sanchez-Beato <alfonso.sanchez-beato@canonical.com>
 Date: Mon, 15 Feb 2016 19:36:32 +0100
-Subject: [PATCH 41/42] (halium) init: Handle udev event peaks
+Subject: [PATCH 41/44] (halium) init: Handle udev event peaks
 
 There were peaks of udev events that made poll fail with POLLERR, being
 the socket error ENOBUFS. This made ueventd exit. We increase the

--- a/system/core/0042-hybris-invoke-queue_fs_event-FS_MGR_MNTALL_DEV_NOT_E.patch
+++ b/system/core/0042-hybris-invoke-queue_fs_event-FS_MGR_MNTALL_DEV_NOT_E.patch
@@ -1,7 +1,7 @@
 From 0ed26c1815e5243b2408063e55234cc7f86fab3b Mon Sep 17 00:00:00 2001
 From: NeKit <nekit1000@gmail.com>
 Date: Tue, 10 Sep 2019 01:12:35 +0200
-Subject: [PATCH 42/42] (hybris) invoke
+Subject: [PATCH 42/44] (hybris) invoke
  queue_fs_event(FS_MGR_MNTALL_DEV_NOT_ENCRYPTED)
 
 Needed to fix MediaTek nvram daemon startup issues, as Mer way of triggering late_start

--- a/system/core/0043-halium-Disable-lmkd-and-turn-it-into-non-critical-se.patch
+++ b/system/core/0043-halium-Disable-lmkd-and-turn-it-into-non-critical-se.patch
@@ -1,7 +1,8 @@
 From 31fe88b18efe0f4c7908b2e142c038ff0058baef Mon Sep 17 00:00:00 2001
 From: Alfred Neumayer <dev.beidl@gmail.com>
 Date: Wed, 15 Apr 2020 20:08:59 +0000
-Subject: [PATCH] (halium): Disable lmkd and turn it into non-critical service
+Subject: [PATCH 43/44] (halium) Disable lmkd and turn it into non-critical
+ service
 
 Change-Id: I5df9f45f4410d87d33f8ad47966b8ea6f743a6df
 ---

--- a/system/core/0044-halium-init-ignore-non-kernel-messages-in-ReadUevent.patch
+++ b/system/core/0044-halium-init-ignore-non-kernel-messages-in-ReadUevent.patch
@@ -1,7 +1,7 @@
 From 9603a4cff66de1c5f6851ff5d72265255743a1b0 Mon Sep 17 00:00:00 2001
 From: NeKit <nekit1000@gmail.com>
 Date: Sun, 19 Apr 2020 23:47:38 +0200
-Subject: [PATCH] (halium) init: ignore non-kernel messages in ReadUevent
+Subject: [PATCH 44/44] (halium) init: ignore non-kernel messages in ReadUevent
 
 Do not abort processing pending uevents in case uevent_kernel_multicast_recv
 returns EIO errno.


### PR DESCRIPTION
a6e2dec is a patch I sent upstream that got merged to the [hybris-16.0 branch](https://github.com/mer-hybris/hybris-patches/commits/hybris-16.0)
ff69733 fixes a bunch of minor visual-only issues when applying patches
d35c5e9 is something I've had sitting in a [PR upstream](https://github.com/mer-hybris/hybris-patches/pull/6) but as it turns out it also helps to massively speed up applying fixes even outside of a chroot (e.g. building Halium 9) if you have GPG signing of your git commits enabled like I do:

Video preview **without** d35c5e9 applied (~9s to apply all patches)
https://i.imgur.com/PB8083h.mp4

Video preview **with** d35c5e9 applied (~250ms seconds to apply all patches)
https://i.imgur.com/RzOJiwB.mp4