### PR TITLE
(halium) system/core: Set up runtime mounts in recovery mode

### DIFF
--- a/system/core/0045-init-Set-up-runtime-mounts-in-recovery-mode.patch
+++ b/system/core/0045-init-Set-up-runtime-mounts-in-recovery-mode.patch
@@ -1,0 +1,77 @@
+From 19486ff85b69312fb9ce8808cda69fa2303db5e8 Mon Sep 17 00:00:00 2001
+From: Alfred Neumayer <dev.beidl@gmail.com>
+Date: Fri, 17 Jul 2020 13:11:59 +0200
+Subject: [PATCH] init: Set up runtime mounts in recovery mode
+
+As init is also used in the recovery we have to make sure
+that the environment is properly set up, including /proc,
+/sys and the other runtime directories.
+
+Change-Id: I3eb17b4de04d4956092b3e94c121737c1af4f9fb
+---
+ init/init.cpp | 30 ++++++++++++++++++++++--------
+ 1 file changed, 22 insertions(+), 8 deletions(-)
+
+diff --git a/init/init.cpp b/init/init.cpp
+index 5d63381..8fd4d67 100644
+--- a/init/init.cpp
++++ b/init/init.cpp
+@@ -546,6 +546,11 @@ static void InstallSigtermHandler() {
+     register_epoll_handler(sigterm_signal_fd, HandleSigtermSignal);
+ }
+ 
++// Copied from init_first_stage.cpp
++static bool inline IsRecoveryMode() {
++    return access("/sbin/recovery", F_OK) == 0;
++}
++
+ int main(int argc, char** argv) {
+     if (!strcmp(basename(argv[0]), "ueventd")) {
+         return ueventd_main(argc, argv);
+@@ -577,17 +582,24 @@ int main(int argc, char** argv) {
+         setenv("PATH", _PATH_DEFPATH, 1);
+         // Get the basic filesystem setup we need put together in the initramdisk
+         // on / and then we'll let the rc file figure out the rest.
+-        //mount("tmpfs", "/dev", "tmpfs", MS_NOSUID, "mode=0755");
+-        //mkdir("/dev/pts", 0755);
++        bool is_recovery = IsRecoveryMode();
++        if (is_recovery) {
++            mount("tmpfs", "/dev", "tmpfs", MS_NOSUID, "mode=0755");
++            mkdir("/dev/pts", 0755);
++        }
+         mkdir("/dev/socket", 0755);
+-        //mount("devpts", "/dev/pts", "devpts", 0, NULL);
+-        #define MAKE_STR(x) __STRING(x)
+-        //mount("proc", "/proc", "proc", 0, "hidepid=2,gid=" MAKE_STR(AID_READPROC));
++        if (is_recovery) {
++            mount("devpts", "/dev/pts", "devpts", 0, NULL);
++            #define MAKE_STR(x) __STRING(x)
++            mount("proc", "/proc", "proc", 0, "hidepid=2,gid=" MAKE_STR(AID_READPROC));
++        }
+         // Don't expose the raw commandline to unprivileged processes.
+         chmod("/proc/cmdline", 0440);
+         gid_t groups[] = { AID_READPROC };
+         setgroups(arraysize(groups), groups);
+-        //mount("sysfs", "/sys", "sysfs", 0, NULL);
++        if (is_recovery) {
++            mount("sysfs", "/sys", "sysfs", 0, NULL);
++        }
+         mount("selinuxfs", "/sys/fs/selinux", "selinuxfs", 0, NULL);
+ 
+         mknod("/dev/kmsg", S_IFCHR | 0600, makedev(1, 11));
+@@ -601,8 +613,10 @@ int main(int argc, char** argv) {
+ 
+         // Mount staging areas for devices managed by vold
+         // See storage config details at http://source.android.com/devices/storage/
+-        //mount("tmpfs", "/mnt", "tmpfs", MS_NOEXEC | MS_NOSUID | MS_NODEV,
+-        //      "mode=0755,uid=0,gid=1000");
++        if (is_recovery) {
++            mount("tmpfs", "/mnt", "tmpfs", MS_NOEXEC | MS_NOSUID | MS_NODEV,
++                  "mode=0755,uid=0,gid=1000");
++        }
+         // /mnt/vendor is used to mount vendor-specific partitions that can not be
+         // part of the vendor partition, e.g. because they are mounted read-write.
+         mkdir("/mnt/vendor", 0755);
+-- 
+2.25.1
+


### PR DESCRIPTION
As init is also used in the recovery we have to make sure
that the environment is properly set up, including /proc,
/sys and the other runtime directories.