### PR TITLE
(halium) CCodec 2.0 enablement

### DIFF
--- a/hardware/google/av/0001-CCodec-Force-androidmedia-compatible-color-formats.patch
+++ b/hardware/google/av/0001-CCodec-Force-androidmedia-compatible-color-formats.patch
@@ -1,0 +1,53 @@
+From 59881cfd80b94f321909670927ba0bfd799b7b70 Mon Sep 17 00:00:00 2001
+From: Alfred Neumayer <dev.beidl@gmail.com>
+Date: Wed, 14 Oct 2020 00:55:42 +0200
+Subject: [PATCH] CCodec: Force androidmedia-compatible color formats
+
+Only advertise color formats that are compatible as well as forcing
+COLOR_FormatYUV420Planar for decoder surfaces.
+
+Change-Id: Idd2ba758540779e626c610da2c76d890170d6a76
+---
+ media/sfplugin/CCodec.cpp            | 2 +-
+ media/sfplugin/Codec2InfoBuilder.cpp | 8 ++++----
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/media/sfplugin/CCodec.cpp b/media/sfplugin/CCodec.cpp
+index 1e74658..d9a38b6 100644
+--- a/media/sfplugin/CCodec.cpp
++++ b/media/sfplugin/CCodec.cpp
+@@ -766,7 +766,7 @@ void CCodec::configure(const sp<AMessage> &msg) {
+                  * needed for decoders.
+                  */
+                 if (!(config->mDomain & Config::IS_ENCODER)) {
+-                    format = (surface == nullptr) ? COLOR_FormatYUV420Planar : COLOR_FormatSurface;
++                    format = COLOR_FormatYUV420Planar;
+                 }
+             }
+ 
+diff --git a/media/sfplugin/Codec2InfoBuilder.cpp b/media/sfplugin/Codec2InfoBuilder.cpp
+index d883d46..742c3fb 100644
+--- a/media/sfplugin/Codec2InfoBuilder.cpp
++++ b/media/sfplugin/Codec2InfoBuilder.cpp
+@@ -593,14 +593,14 @@ status_t Codec2InfoBuilder::buildMediaCodecList(MediaCodecListWriter* writer) {
+             // MediaCodec color formats?
+             if (mediaType.find("video") != std::string::npos) {
+                 // vendor video codecs prefer opaque format
+-                if (trait.name.find("android") == std::string::npos) {
++                /*if (trait.name.find("android") == std::string::npos) {
+                     caps->addColorFormat(COLOR_FormatSurface);
+-                }
++                }*/
+                 caps->addColorFormat(COLOR_FormatYUV420Flexible);
+                 caps->addColorFormat(COLOR_FormatYUV420Planar);
+                 caps->addColorFormat(COLOR_FormatYUV420SemiPlanar);
+-                caps->addColorFormat(COLOR_FormatYUV420PackedPlanar);
+-                caps->addColorFormat(COLOR_FormatYUV420PackedSemiPlanar);
++                //caps->addColorFormat(COLOR_FormatYUV420PackedPlanar);
++                //caps->addColorFormat(COLOR_FormatYUV420PackedSemiPlanar);
+                 // framework video encoders must support surface format, though it is unclear
+                 // that they will be able to map it if it is opaque
+                 if (encoder && trait.name.find("android") != std::string::npos) {
+-- 
+2.25.1
+

--- a/hardware/google/av/0002-Client-Filter-out-non-qti-codecs.patch
+++ b/hardware/google/av/0002-Client-Filter-out-non-qti-codecs.patch
@@ -1,4 +1,4 @@
-From 40f1680694124e807f43c375d0849c9d4a82671b Mon Sep 17 00:00:00 2001
+From 10e0f9321bde831b5f8854edb457f3df5037c303 Mon Sep 17 00:00:00 2001
 From: Alfred Neumayer <dev.beidl@gmail.com>
 Date: Wed, 14 Oct 2020 00:57:01 +0200
 Subject: [PATCH] Client: Filter out non-qti codecs
@@ -10,14 +10,14 @@ Filter out any codecs that would be considered software decoders
 
 Change-Id: I5f401bb50eef7f96a836de6390f84d9307de501f
 ---
- codec2/hidl/client/client.cpp | 12 +++++++++++-
- 1 file changed, 11 insertions(+), 1 deletion(-)
+ codec2/hidl/client/client.cpp | 19 ++++++++++++++++++-
+ 1 file changed, 18 insertions(+), 1 deletion(-)
 
 diff --git a/codec2/hidl/client/client.cpp b/codec2/hidl/client/client.cpp
-index ff67681..5e5ce88 100644
+index ff67681..2509ac6 100644
 --- a/codec2/hidl/client/client.cpp
 +++ b/codec2/hidl/client/client.cpp
-@@ -548,16 +548,26 @@ const std::vector<C2Component::Traits>& Codec2Client::listComponents() const {
+@@ -548,16 +548,33 @@ const std::vector<C2Component::Traits>& Codec2Client::listComponents() const {
      }
      Return<void> transStatus = base()->listComponents(
              [this](const hidl_vec<IComponentStore::ComponentTraits>& t) {
@@ -25,10 +25,17 @@ index ff67681..5e5ce88 100644
                  mTraitsList.resize(t.size());
                  mAliasesBuffer.resize(t.size());
                  for (size_t i = 0; i < t.size(); ++i) {
-+                    if (((std::string)t[i].name).find("c2.qti.") != 0) {
++                    std::string componentName = (std::string)(t[i].name);
++                    ALOGI("listComponents: %s", componentName.c_str());
++                    if ((componentName.find(".encoder") == std::string::npos) &&
++                          ((componentName.find("c2.android.") == 0) ||
++                          (componentName.find("OMX.google.") == 0) ||
++                          (componentName.find("OMX.qcom.") == 0))) {
 +                        ++removeCounter;
 +                        continue;
 +                    }
++
++                    ALOGI("Accepting component '%s'", componentName.c_str());
 +
                      c2_status_t status = objcpy(
 -                            &mTraitsList[i], &mAliasesBuffer[i], t[i]);

--- a/hardware/google/av/0002-Client-Filter-out-non-qti-codecs.patch
+++ b/hardware/google/av/0002-Client-Filter-out-non-qti-codecs.patch
@@ -1,0 +1,50 @@
+From 40f1680694124e807f43c375d0849c9d4a82671b Mon Sep 17 00:00:00 2001
+From: Alfred Neumayer <dev.beidl@gmail.com>
+Date: Wed, 14 Oct 2020 00:57:01 +0200
+Subject: [PATCH] Client: Filter out non-qti codecs
+
+Android uses a ranking system to prefer certain codecs over others,
+whereas gsthybrissink doesn't make use of it.
+
+Filter out any codecs that would be considered software decoders
+
+Change-Id: I5f401bb50eef7f96a836de6390f84d9307de501f
+---
+ codec2/hidl/client/client.cpp | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/codec2/hidl/client/client.cpp b/codec2/hidl/client/client.cpp
+index ff67681..5e5ce88 100644
+--- a/codec2/hidl/client/client.cpp
++++ b/codec2/hidl/client/client.cpp
+@@ -548,16 +548,26 @@ const std::vector<C2Component::Traits>& Codec2Client::listComponents() const {
+     }
+     Return<void> transStatus = base()->listComponents(
+             [this](const hidl_vec<IComponentStore::ComponentTraits>& t) {
++                int removeCounter = 0;
+                 mTraitsList.resize(t.size());
+                 mAliasesBuffer.resize(t.size());
+                 for (size_t i = 0; i < t.size(); ++i) {
++                    if (((std::string)t[i].name).find("c2.qti.") != 0) {
++                        ++removeCounter;
++                        continue;
++                    }
++
+                     c2_status_t status = objcpy(
+-                            &mTraitsList[i], &mAliasesBuffer[i], t[i]);
++                            &mTraitsList[i - removeCounter],
++                            &mAliasesBuffer[i - removeCounter],
++                            t[i]);
+                     if (status != C2_OK) {
+                         ALOGE("listComponents -- corrupted output.");
+                         return;
+                     }
+                 }
++                mTraitsList.resize(t.size() - removeCounter);
++                mAliasesBuffer.resize(t.size() - removeCounter);
+             });
+     if (!transStatus.isOk()) {
+         ALOGE("listComponents -- failed transaction.");
+-- 
+2.25.1
+


### PR DESCRIPTION
-) CCodec: Force COLOR_FormatYUV420Flexible as color format (opaque COLOR_FormatSurface is not supported)
-) Client: Filter out non-qti codecs (enables hardware accelerated decoding and rendering)