### PR TITLE
update_engine: add back missing header file

### DIFF
--- a/system/update_engine/0001-Add-missing-header-file.patch
+++ b/system/update_engine/0001-Add-missing-header-file.patch
@@ -1,0 +1,67 @@
+From a0a496d401bd4553e4d6d44f4df924f722bd670e Mon Sep 17 00:00:00 2001
+From: Caleb Connolly <caleb@connolly.tech>
+Date: Sun, 22 Dec 2019 21:55:48 +0000
+Subject: [PATCH] Add missing header file (?)
+
+---
+ dbus-constants.h | 51 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 51 insertions(+)
+ create mode 100644 dbus-constants.h
+
+diff --git a/dbus-constants.h b/dbus-constants.h
+new file mode 100644
+index 00000000..aa640460
+--- /dev/null
++++ b/dbus-constants.h
+@@ -0,0 +1,51 @@
++// Copyright 2015 The Chromium OS Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef SYSTEM_API_DBUS_UPDATE_ENGINE_DBUS_CONSTANTS_H_
++#define SYSTEM_API_DBUS_UPDATE_ENGINE_DBUS_CONSTANTS_H_
++
++namespace update_engine {
++const char kUpdateEngineInterface[] = "org.chromium.UpdateEngineInterface";
++const char kUpdateEngineServicePath[] = "/org/chromium/UpdateEngine";
++const char kUpdateEngineServiceName[] = "org.chromium.UpdateEngine";
++
++// Generic UpdateEngine D-Bus error.
++const char kUpdateEngineServiceErrorFailed[] =
++    "org.chromium.UpdateEngine.Error.Failed";
++
++// Methods.
++const char kAttemptUpdate[] = "AttemptUpdate";
++const char kGetStatus[] = "GetStatus";
++const char kRebootIfNeeded[] = "RebootIfNeeded";
++const char kSetChannel[] = "SetChannel";
++const char kGetChannel[] = "GetChannel";
++const char kAttemptRollback[] = "AttemptRollback";
++const char kCanRollback[] = "CanRollback";
++
++// Signals.
++const char kStatusUpdate[] = "StatusUpdate";
++
++// Flags used in the AttemptUpdateWithFlags() D-Bus method.
++typedef enum {
++  kAttemptUpdateFlagNonInteractive = (1 << 0)
++} AttemptUpdateFlags;
++
++// Operations contained in StatusUpdate signals.
++const char kUpdateStatusIdle[] = "UPDATE_STATUS_IDLE";
++const char kUpdateStatusCheckingForUpdate[] =
++    "UPDATE_STATUS_CHECKING_FOR_UPDATE";
++const char kUpdateStatusUpdateAvailable[] = "UPDATE_STATUS_UPDATE_AVAILABLE";
++const char kUpdateStatusDownloading[] = "UPDATE_STATUS_DOWNLOADING";
++const char kUpdateStatusVerifying[] = "UPDATE_STATUS_VERIFYING";
++const char kUpdateStatusFinalizing[] = "UPDATE_STATUS_FINALIZING";
++const char kUpdateStatusUpdatedNeedReboot[] =
++    "UPDATE_STATUS_UPDATED_NEED_REBOOT";
++const char kUpdateStatusReportingErrorEvent[] =
++    "UPDATE_STATUS_REPORTING_ERROR_EVENT";
++const char kUpdateStatusAttemptingRollback[] =
++    "UPDATE_STATUS_ATTEMPTING_ROLLBACK";
++const char kUpdateStatusDisabled[] = "UPDATE_STATUS_DISABLED";
++}  // namespace update_engine
++
++#endif  // SYSTEM_API_DBUS_UPDATE_ENGINE_DBUS_CONSTANTS_H_


### PR DESCRIPTION
update_engine had a header file removed that for some reason can't be found on hybris based builds on the OnePlus 6 at least, add back the header to make it happy.