### PR TITLE
(halium) frameworks/av: whitespace fix

### DIFF
--- a/frameworks/av/0006-halium-Enable-video-and-audio-recording-from-camera.patch
+++ b/frameworks/av/0006-halium-Enable-video-and-audio-recording-from-camera.patch
@@ -117,7 +117,7 @@ index 00788a5..8303cfb 100644
          goto exit;
      }
 -    ALOG_ASSERT(record != 0);
-+    
++
 +    record = recording.ar;
 +    iMem = recording.cblk;
 +    bufferMem = recording.buffers;


### PR DESCRIPTION
Remove unnecessary whitespace which causes `git am` to emit a warning
when applying this patch.

Change-Id: I91d321ccbc0e2c13b04cdf9fc48de4c8837ad477