### PR TITLE
(halium) frameworks/native: leave vndservicemanager in vendor partition

### DIFF
--- a/frameworks/native/0008-halium-include-vndservicemanager-into-system-partiti.patch
+++ b/frameworks/native/0008-halium-include-vndservicemanager-into-system-partiti.patch
@@ -1,27 +1,28 @@
 From 87adc861590c7546a176fe0f665c52f4bd82d8b3 Mon Sep 17 00:00:00 2001
 From: NeKit <nekit1000@gmail.com>
 Date: Sun, 9 Feb 2020 20:13:50 +0100
-Subject: [PATCH 8/9] (halium) include vndservicemanager into system partition
+Subject: [PATCH 8/9] (halium) include vndservicemanager.rc into system partition
  to override service
 
 Change-Id: Ia77e6be009a4410aa8a05351a192e9d4dfe22c87
 ---
- cmds/servicemanager/Android.bp           | 1 -
+ cmds/servicemanager/Android.bp           | 2 +-
  cmds/servicemanager/vndservicemanager.rc | 1 +
- 2 files changed, 1 insertion(+), 1 deletion(-)
+ 2 files changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/cmds/servicemanager/Android.bp b/cmds/servicemanager/Android.bp
 index 428561b..a552ba2 100644
 --- a/cmds/servicemanager/Android.bp
 +++ b/cmds/servicemanager/Android.bp
-@@ -38,7 +38,6 @@ cc_binary {
- cc_binary {
-     name: "vndservicemanager",
-     defaults: ["servicemanager_flags"],
--    vendor: true,
-     srcs: [
-         "service_manager.c",
+@@ -32,7 +32,7 @@ cc_binary {
          "binder.c",
+     ],
+     shared_libs: ["libcutils", "libselinux"],
+-    init_rc: ["servicemanager.rc"],
++    init_rc: ["servicemanager.rc", "vndservicemanager.rc"],
+ }
+
+ cc_binary {
 diff --git a/cmds/servicemanager/vndservicemanager.rc b/cmds/servicemanager/vndservicemanager.rc
 index 3fa4d7d..a754c47 100644
 --- a/cmds/servicemanager/vndservicemanager.rc


### PR DESCRIPTION
Copy vndservicemanager.rc together with servicemanager.rc into /system/etc/init for service override.