### PR TITLE
(halium) build/make: include BootSignature and VeritySigner for host

### DIFF
--- a/build/make/0003-halium-add-basic-Halium-build-configuration-based-on.patch
+++ b/build/make/0003-halium-add-basic-Halium-build-configuration-based-on.patch
@@ -1,13 +1,13 @@
 From eac97d5bd6323f49408109d59f7aa7d2f7f40499 Mon Sep 17 00:00:00 2001
 From: NeKit <nekit1000@gmail.com>
 Date: Sun, 9 Feb 2020 18:35:53 +0100
-Subject: [PATCH 4/5] (halium) add basic Halium build configuration based on
+Subject: [PATCH 3/5] (halium) add basic Halium build configuration based on
  embedded.mk
 
 Change-Id: I7ce0e771a5bdd0a94bd43af35bbfff3edc75dfd1
 ---
- target/product/halium.mk | 42 ++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 42 insertions(+)
+ target/product/halium.mk | 44 ++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 44 insertions(+)
  create mode 100644 target/product/halium.mk
 
 diff --git a/target/product/halium.mk b/target/product/halium.mk
@@ -15,7 +15,7 @@ new file mode 100644
 index 0000000..166bf05
 --- /dev/null
 +++ b/target/product/halium.mk
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,44 @@
 +# Required Android parts not included by embedded.mk
 +PRODUCT_PACKAGES += \
 +    android.system.net.netd@1.1-service.stub \
@@ -35,10 +35,12 @@ index 0000000..166bf05
 +
 +# Produce binaries needed on host
 +PRODUCT_PACKAGES += \
++    BootSignature \
 +    fec \
 +    mke2fs \
 +    mkuserimg_mke2fs.sh \
-+    mkimage
++    mkimage \
++    VeritySigner
 +
 +# Halium-specific packages
 +PRODUCT_PACKAGES += \


### PR DESCRIPTION
UBPorts CI builds for OnePlus 5 and Pixel started to fail after a change to drop hybris-boot got merged with the following:
`Error: Unable to access jarfile /opt/halium_build/9.0/out/host/linux-x86/framework/BootSignature.jar`

I did not figure out how it was related, however it seems reasonable to include BootSignature and VeritySigner into halium.mk since we do not pull in otatools target it is part of (defined in build/make/core/Makefile).