### PR TITLE
build & external: Support building on Darwin/macOS

### DIFF
--- a/build/soong/0002-x86_darwin_host-Allow-building-with-macOS-11.3-SDK.patch
+++ b/build/soong/0002-x86_darwin_host-Allow-building-with-macOS-11.3-SDK.patch
@@ -1,0 +1,27 @@
+From 90a40ef6780af219fc0ef1ea6052a5241333daba Mon Sep 17 00:00:00 2001
+From: Alfred Neumayer <dev.beidl@gmail.com>
+Date: Thu, 24 Jun 2021 19:46:44 +0200
+Subject: [PATCH] x86_darwin_host: Allow building with macOS 11.3 SDK
+
+This enables building with Xcode 12.5 installed.
+
+Change-Id: Ib68b631e95d154bdc1805facf5400e8f9d4c9d54
+---
+ cc/config/x86_darwin_host.go | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/cc/config/x86_darwin_host.go b/cc/config/x86_darwin_host.go
+index 52d63514..1c7eb4ec 100644
+--- a/cc/config/x86_darwin_host.go
++++ b/cc/config/x86_darwin_host.go
+@@ -83,6 +83,7 @@ var (
+ 		"10.12",
+ 		"10.13",
+ 		"10.14",
++		"11.3",
+ 	}
+ 
+ 	darwinAvailableLibraries = append(
+-- 
+2.30.1 (Apple Git-130)
+

--- a/external/elfutils/0001-elf.h-Add-missing-__BEGIN_DECLS-__END_DECLS-defines.patch
+++ b/external/elfutils/0001-elf.h-Add-missing-__BEGIN_DECLS-__END_DECLS-defines.patch
@@ -1,0 +1,39 @@
+From b788a677b4a201d4f12d31e3f5f95a323c39a20b Mon Sep 17 00:00:00 2001
+From: Alfred Neumayer <dev.beidl@gmail.com>
+Date: Thu, 24 Jun 2021 19:53:26 +0200
+Subject: [PATCH] elf.h: Add missing __BEGIN_DECLS & __END_DECLS defines
+
+These defines seem to be Linux-specific and not available on
+macOS by default, so add them here where they're needed.
+
+This allows building kernel images on macOS.
+
+Change-Id: I25a30179f7fa595a47a0ea366ebd411f64f1b57d
+---
+ libelf/elf.h | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/libelf/elf.h b/libelf/elf.h
+index 9e9ffdc2..bcc89454 100644
+--- a/libelf/elf.h
++++ b/libelf/elf.h
+@@ -23,6 +23,16 @@
+ #include <features.h>
+ #endif
+ 
++#ifdef __APPLE__
++#ifdef __cplusplus
++# define __BEGIN_DECLS extern "C" {
++# define __END_DECLS }
++#else
++# define __BEGIN_DECLS /* empty */
++# define __END_DECLS /* empty */
++#endif
++#endif
++
+ __BEGIN_DECLS
+ 
+ /* Standard ELF types.  */
+-- 
+2.30.1 (Apple Git-130)
+

--- a/external/libbrillo/0001-Android.bp-Avoid-building-on-Darwin.patch
+++ b/external/libbrillo/0001-Android.bp-Avoid-building-on-Darwin.patch
@@ -1,0 +1,71 @@
+From 6d05f137048f34c0e004155f7541394ab42857fe Mon Sep 17 00:00:00 2001
+From: Alfred Neumayer <dev.beidl@gmail.com>
+Date: Thu, 24 Jun 2021 19:50:04 +0200
+Subject: [PATCH] Android.bp: Avoid building on Darwin
+
+By default libbrillo builds on macOS using AppKit, which
+causes ill-formatted headers to be included.
+So for the sanity of everyone involved, just disable building
+the component on macOS completely.
+
+Change-Id: If4ce9b93d45404005ecc33de697564e0ea7758f8
+---
+ Android.bp | 22 +++++++++-------------
+ 1 file changed, 9 insertions(+), 13 deletions(-)
+
+diff --git a/Android.bp b/Android.bp
+index af10fa8..17c9549 100644
+--- a/Android.bp
++++ b/Android.bp
+@@ -148,6 +148,9 @@ cc_library {
+         android: {
+             srcs: libbrillo_linux_sources,
+         },
++        darwin: {
++            enabled: false
++        }
+     },
+ }
+ 
+@@ -199,16 +202,12 @@ cc_library {
+ 
+     host_supported: true,
+     target: {
+-        darwin: {
+-            cflags: [
+-                "-D_FILE_OFFSET_BITS=64",
+-                "-Doff64_t=off_t",
+-                "-Dlseek64=lseek",
+-            ],
+-        },
+         windows: {
+             enabled: false,
+         },
++        darwin: {
++            enabled: false
++        }
+     },
+ }
+ 
+@@ -228,15 +227,12 @@ cc_library_shared {
+ 
+     host_supported: true,
+     target: {
+-        darwin: {
+-            cflags: [
+-                "-D_FILE_OFFSET_BITS=64",
+-                "-Doff64_t=off_t",
+-            ],
+-        },
+         windows: {
+             enabled: false,
+         },
++        darwin: {
++            enabled: false
++        }
+     },
+ }
+ 
+-- 
+2.30.1 (Apple Git-130)
+

--- a/external/libchrome/0001-Android.bp-Avoid-building-on-Darwin.patch
+++ b/external/libchrome/0001-Android.bp-Avoid-building-on-Darwin.patch
@@ -1,0 +1,39 @@
+From 60b90e1062ac31eaf2f084c15585db820c34aaf0 Mon Sep 17 00:00:00 2001
+From: Alfred Neumayer <dev.beidl@gmail.com>
+Date: Thu, 24 Jun 2021 19:51:34 +0200
+Subject: [PATCH] Android.bp: Avoid building on Darwin
+
+By default libchrome builds on macOS using AppKit, which
+causes ill-formatted headers to be included.
+So for the sanity of everyone involved, just disable building
+the component on macOS completely.
+
+Change-Id: I2c7f993b2d5908fa8b3349058a5e028f98ee63ba
+---
+ Android.bp | 10 +---------
+ 1 file changed, 1 insertion(+), 9 deletions(-)
+
+diff --git a/Android.bp b/Android.bp
+index 9dfffca..0d3752d 100644
+--- a/Android.bp
++++ b/Android.bp
+@@ -57,15 +57,7 @@ cc_defaults {
+             ],
+         },
+         darwin: {
+-            cflags: [
+-                "-D_FILE_OFFSET_BITS=64",
+-            ],
+-            host_ldlibs: [
+-                "-framework AppKit",
+-                "-framework CoreFoundation",
+-                "-framework Foundation",
+-                "-framework Security",
+-            ],
++            enabled: false,
+         },
+     },
+ }
+-- 
+2.30.1 (Apple Git-130)
+

--- a/external/python/cpython2/0001-getpath-Set-nsexeclength-as-uint32_t.patch
+++ b/external/python/cpython2/0001-getpath-Set-nsexeclength-as-uint32_t.patch
@@ -1,0 +1,31 @@
+From 019ac7d7aca89c5ce5edfd79fc79d2882c3df4e0 Mon Sep 17 00:00:00 2001
+From: Alfred Neumayer <dev.beidl@gmail.com>
+Date: Thu, 24 Jun 2021 19:59:59 +0200
+Subject: [PATCH] getpath: Set nsexeclength as uint32_t
+
+This fixes a FTBFS on macOS Big Sur.
+
+Change-Id: I35dafdcdaa9cdabc892a766552ec9a0660f87837
+---
+ Modules/getpath.c | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/Modules/getpath.c b/Modules/getpath.c
+index e9d969bd1f..03520b976a 100644
+--- a/Modules/getpath.c
++++ b/Modules/getpath.c
+@@ -439,11 +439,7 @@ calculate_path(void)
+     NSModule pythonModule;
+ #endif
+ #ifdef __APPLE__
+-#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_4
+     uint32_t nsexeclength = MAXPATHLEN;
+-#else
+-    unsigned long nsexeclength = MAXPATHLEN;
+-#endif
+ #endif
+ 
+         /* If there is no slash in the argv0 path, then we have to
+-- 
+2.30.1 (Apple Git-130)
+


### PR DESCRIPTION
- Allow building with a macOS SDK 11.3
- Fix missing 'extern "C"' defines in efutils
- Avoid building libchrome & libbrillo for the host OS on Darwin
- Fix FTBFS in cpython2 where nsexeclength was using the wrong type

Halium ports for distributions that require AppArmor need a patch
similar to this one: https://github.com/fredldotme/android_kernel_google_bonito/commit/a88b86ebfb0959de9d919aa0646586c3f1e4825f