### PR TITLE
(halium) system/core: ensure we do not break recovery

### DIFF
--- a/system/core/0001-anbox-init-start-inside-LXC-container-without-SELinu.patch
+++ b/system/core/0001-anbox-init-start-inside-LXC-container-without-SELinu.patch
@@ -1,17 +1,22 @@
-From 7967b452fb5d0d883cd459f5e33da841f6148806 Mon Sep 17 00:00:00 2001
+From 1571e850f924a491494f3cd154bc3f8c33f527f6 Mon Sep 17 00:00:00 2001
 From: Asriel Dreemurr <asriel.danctnix@gmail.com>
 Date: Sun, 18 Oct 2020 00:31:45 +0700
-Subject: [PATCH 1/4] (anbox) init: start inside LXC container without SELinux
+Subject: [PATCH] (anbox) init: start inside LXC container without SELinux
 
+amartinz: keep first stage init setup for recovery, otherwise
+recovery will not boot.
+
+Change-Id: I1d4181f07b662f513db621a66f78348295a3862a
+Signed-off-by: Alexander Martinz <alex@amartinz.at>
 ---
  init/Android.bp           |  2 ++
- init/first_stage_init.cpp | 31 ++++++++++++++++++++-----------
- init/init.cpp             | 14 +++++++++-----
- init/property_service.cpp | 24 +++++++++++++++---------
- init/service.cpp          | 10 ++++++----
+ init/first_stage_init.cpp | 47 ++++++++++++++++++++++++++++++---------
+ init/init.cpp             | 14 +++++++-----
+ init/property_service.cpp | 24 ++++++++++++--------
+ init/service.cpp          | 10 +++++----
  init/subcontext.cpp       |  5 +++--
- init/util.cpp             | 18 +++++++++++-------
- 7 files changed, 66 insertions(+), 38 deletions(-)
+ init/util.cpp             | 18 +++++++++------
+ 7 files changed, 82 insertions(+), 38 deletions(-)
 
 diff --git a/init/Android.bp b/init/Android.bp
 index 377a3740c..9dda6897f 100644
@@ -34,26 +39,34 @@ index 377a3740c..9dda6897f 100644
      ],
      static_libs: [
 diff --git a/init/first_stage_init.cpp b/init/first_stage_init.cpp
-index 2b899408a..b148fb231 100644
+index 2b899408a..6b86e12f7 100644
 --- a/init/first_stage_init.cpp
 +++ b/init/first_stage_init.cpp
-@@ -117,19 +117,22 @@ int FirstStageMain(int argc, char** argv) {
+@@ -117,19 +117,31 @@ int FirstStageMain(int argc, char** argv) {
      CHECKCALL(setenv("PATH", _PATH_DEFPATH, 1));
      // Get the basic filesystem setup we need put together in the initramdisk
      // on / and then we'll let the rc file figure out the rest.
 -    CHECKCALL(mount("tmpfs", "/dev", "tmpfs", MS_NOSUID, "mode=0755"));
 -    CHECKCALL(mkdir("/dev/pts", 0755));
+-    CHECKCALL(mkdir("/dev/socket", 0755));
+-    CHECKCALL(mount("devpts", "/dev/pts", "devpts", 0, NULL));
++
++    // We need to disable certain things for Anbox while the recovery needs it.
++    bool is_recovery = IsRecoveryMode();
 +
 +    // Disabled for Anbox, mounted by host system instead
-+    //CHECKCALL(mount("tmpfs", "/dev", "tmpfs", MS_NOSUID, "mode=0755"));
-+    //CHECKCALL(mkdir("/dev/pts", 0755));
-     CHECKCALL(mkdir("/dev/socket", 0755));
--    CHECKCALL(mount("devpts", "/dev/pts", "devpts", 0, NULL));
-+    //CHECKCALL(mount("devpts", "/dev/pts", "devpts", 0, NULL));
++    if (!is_recovery) {
++        mkdir("/dev/socket", 0755);
++    } else {
++        CHECKCALL(mount("tmpfs", "/dev", "tmpfs", MS_NOSUID, "mode=0755"));
++        CHECKCALL(mkdir("/dev/pts", 0755));
++        CHECKCALL(mkdir("/dev/socket", 0755));
++        CHECKCALL(mount("devpts", "/dev/pts", "devpts", 0, NULL));
  #define MAKE_STR(x) __STRING(x)
 -    CHECKCALL(mount("proc", "/proc", "proc", 0, "hidepid=2,gid=" MAKE_STR(AID_READPROC)));
-+    //CHECKCALL(mount("proc", "/proc", "proc", 0, "hidepid=2,gid=" MAKE_STR(AID_READPROC)));
++        CHECKCALL(mount("proc", "/proc", "proc", 0, "hidepid=2,gid=" MAKE_STR(AID_READPROC)));
  #undef MAKE_STR
++    }
      // Don't expose the raw commandline to unprivileged processes.
      CHECKCALL(chmod("/proc/cmdline", 0440));
      gid_t groups[] = {AID_READPROC};
@@ -61,46 +74,52 @@ index 2b899408a..b148fb231 100644
 -    CHECKCALL(mount("sysfs", "/sys", "sysfs", 0, NULL));
 -    CHECKCALL(mount("selinuxfs", "/sys/fs/selinux", "selinuxfs", 0, NULL));
 +    // Disabled for Anbox
-+    //CHECKCALL(mount("sysfs", "/sys", "sysfs", 0, NULL));
-+    //CHECKCALL(mount("selinuxfs", "/sys/fs/selinux", "selinuxfs", 0, NULL));
++    if (is_recovery) {
++        CHECKCALL(mount("sysfs", "/sys", "sysfs", 0, NULL));
++        CHECKCALL(mount("selinuxfs", "/sys/fs/selinux", "selinuxfs", 0, NULL));
++    }
  
      CHECKCALL(mknod("/dev/kmsg", S_IFCHR | 0600, makedev(1, 11)));
  
-@@ -141,8 +144,11 @@ int FirstStageMain(int argc, char** argv) {
+@@ -141,8 +153,13 @@ int FirstStageMain(int argc, char** argv) {
      CHECKCALL(mknod("/dev/urandom", S_IFCHR | 0666, makedev(1, 9)));
  
      // This is needed for log wrapper, which gets called before ueventd runs.
 -    CHECKCALL(mknod("/dev/ptmx", S_IFCHR | 0666, makedev(5, 2)));
 -    CHECKCALL(mknod("/dev/null", S_IFCHR | 0666, makedev(1, 3)));
 +    // Can be created by LXC on Anbox
-+    //CHECKCALL(mknod("/dev/ptmx", S_IFCHR | 0666, makedev(5, 2)));
-+    //CHECKCALL(mknod("/dev/null", S_IFCHR | 0666, makedev(1, 3)));
++    if (is_recovery) {
++        CHECKCALL(mknod("/dev/ptmx", S_IFCHR | 0666, makedev(5, 2)));
++        CHECKCALL(mknod("/dev/null", S_IFCHR | 0666, makedev(1, 3)));
++    }
 +    mknod("/dev/ptmx", S_IFCHR | 0666, makedev(5, 2));
 +    mknod("/dev/null", S_IFCHR | 0666, makedev(1, 3));
  
      // These below mounts are done in first stage init so that first stage mount can mount
      // subdirectories of /mnt/{vendor,product}/.  Other mounts, not required by first stage mount,
-@@ -215,9 +221,10 @@ int FirstStageMain(int argc, char** argv) {
+@@ -215,7 +232,8 @@ int FirstStageMain(int argc, char** argv) {
          }
      }
  
 -    if (!DoFirstStageMount()) {
 +    // Disabled for Anbox
-+    /*if (!DoFirstStageMount()) {
++    if (is_recovery && !DoFirstStageMount()) {
          LOG(FATAL) << "Failed to mount required partitions early ...";
--    }
-+    }*/
+     }
  
-     struct stat new_root_info;
-     if (stat("/", &new_root_info) != 0) {
-@@ -236,7 +243,9 @@ int FirstStageMain(int argc, char** argv) {
+@@ -236,7 +254,14 @@ int FirstStageMain(int argc, char** argv) {
      setenv("INIT_STARTED_AT", std::to_string(start_ms).c_str(), 1);
  
      const char* path = "/system/bin/init";
 -    const char* args[] = {path, "selinux_setup", nullptr};
 +    // Anbox: skip selinux_setup
-+    //const char* args[] = {path, "selinux_setup", nullptr};
-+    const char* args[] = {path, "second_stage", nullptr};
++    const char* next_stage;
++    if (is_recovery) {
++        next_stage = "selinux_setup";
++    } else {
++        next_stage = "second_stage";
++    }
++    const char* args[] = {path, next_stage, nullptr};
      execv(path, const_cast<char**>(args));
  
      // execv() only returns if an error happened, in which case we
@@ -326,5 +345,5 @@ index 63d2d4442..516221ca4 100644
      if (ret) {
          errno = savederrno;
 -- 
-2.28.0
+2.32.0
 

--- a/system/core/0002-anbox-init-modify-mount_all-to-skip-mounts-and-trigg.patch
+++ b/system/core/0002-anbox-init-modify-mount_all-to-skip-mounts-and-trigg.patch
@@ -1,7 +1,7 @@
-From bdb2e1ec79c05045473c00853c1108414a64a21f Mon Sep 17 00:00:00 2001
+From 8eead229b8945d9d06ca993d923bdd0436671a8f Mon Sep 17 00:00:00 2001
 From: Asriel Dreemurr <asriel.danctnix@gmail.com>
 Date: Wed, 11 Nov 2020 08:08:51 +0700
-Subject: [PATCH 2/4] (anbox) init: modify mount_all to skip mounts and trigger
+Subject: [PATCH] (anbox) init: modify mount_all to skip mounts and trigger
  nonencrypted state
 
 Change-Id: Iae8cffa6aeb2d56f35a51f0e9f52fd92402c43e9
@@ -54,5 +54,5 @@ index d5afabce8..1fcdb141e 100644
      # Once metadata has been mounted, we'll need vold to deal with userdata checkpointing
      start vold
 -- 
-2.28.0
+2.32.0
 

--- a/system/core/0003-halium-init-adjust-first-stage-mounts-for-Halium.patch
+++ b/system/core/0003-halium-init-adjust-first-stage-mounts-for-Halium.patch
@@ -1,28 +1,19 @@
-From 7484a0a1be7ca00e40e17dc0cd4f6ed6f08c7735 Mon Sep 17 00:00:00 2001
+From 5f02b3ff5dba41dac9dc79a920bb7cd1ee63ff99 Mon Sep 17 00:00:00 2001
 From: TheKit <nekit1000@gmail.com>
 Date: Sat, 19 Dec 2020 21:39:09 +0200
 Subject: [PATCH] (halium) init: adjust first stage mounts for Halium
 
 Change-Id: I575e5f1072e69ffec9eea9adf96988f37f393018
+Signed-off-by: Alexander Martinz <alex@amartinz.at>
 ---
- init/first_stage_init.cpp | 20 +++++++++++++-------
- 1 file changed, 13 insertions(+), 7 deletions(-)
+ init/first_stage_init.cpp | 27 +++++++++++++++++++++------
+ 1 file changed, 21 insertions(+), 6 deletions(-)
 
 diff --git a/init/first_stage_init.cpp b/init/first_stage_init.cpp
-index b148fb231..e6e49ed4a 100644
+index 6b86e12f7..3bc336339 100644
 --- a/init/first_stage_init.cpp
 +++ b/init/first_stage_init.cpp
-@@ -121,7 +121,8 @@ int FirstStageMain(int argc, char** argv) {
-     // Disabled for Anbox, mounted by host system instead
-     //CHECKCALL(mount("tmpfs", "/dev", "tmpfs", MS_NOSUID, "mode=0755"));
-     //CHECKCALL(mkdir("/dev/pts", 0755));
--    CHECKCALL(mkdir("/dev/socket", 0755));
-+    //CHECKCALL(mkdir("/dev/socket", 0755));
-+    mkdir("/dev/socket", 0755);
-     //CHECKCALL(mount("devpts", "/dev/pts", "devpts", 0, NULL));
- #define MAKE_STR(x) __STRING(x)
-     //CHECKCALL(mount("proc", "/proc", "proc", 0, "hidepid=2,gid=" MAKE_STR(AID_READPROC)));
-@@ -155,18 +156,23 @@ int FirstStageMain(int argc, char** argv) {
+@@ -166,18 +166,33 @@ int FirstStageMain(int argc, char** argv) {
      // should be done in rc files.
      // Mount staging areas for devices managed by vold
      // See storage config details at http://source.android.com/devices/storage/
@@ -30,28 +21,38 @@ index b148fb231..e6e49ed4a 100644
 -                    "mode=0755,uid=0,gid=1000"));
 +
 +    // Disabled for Halium, mounted by LXC config
-+    //CHECKCALL(mount("tmpfs", "/mnt", "tmpfs", MS_NOEXEC | MS_NOSUID | MS_NODEV,
-+    //                "mode=0755,uid=0,gid=1000"));
++    if (is_recovery) {
++        CHECKCALL(mount("tmpfs", "/mnt", "tmpfs", MS_NOEXEC | MS_NOSUID | MS_NODEV,
++                        "mode=0755,uid=0,gid=1000"));
++    }
      // /mnt/vendor is used to mount vendor-specific partitions that can not be
      // part of the vendor partition, e.g. because they are mounted read-write.
 -    CHECKCALL(mkdir("/mnt/vendor", 0755));
-+    //CHECKCALL(mkdir("/mnt/vendor", 0755));
-+    mkdir("/mnt/vendor", 0755);
++    if (is_recovery) {
++        CHECKCALL(mkdir("/mnt/vendor", 0755));
++    } else {
++        mkdir("/mnt/vendor", 0755);
++    }
      // /mnt/product is used to mount product-specific partitions that can not be
      // part of the product partition, e.g. because they are mounted read-write.
 -    CHECKCALL(mkdir("/mnt/product", 0755));
-+    //CHECKCALL(mkdir("/mnt/product", 0755));
-+    mkdir("/mnt/product", 0755);
++    if (is_recovery) {
++        CHECKCALL(mkdir("/mnt/product", 0755));
++    } else {
++        mkdir("/mnt/product", 0755);
++    }
  
      // /apex is used to mount APEXes
 -    CHECKCALL(mount("tmpfs", "/apex", "tmpfs", MS_NOEXEC | MS_NOSUID | MS_NODEV,
 -                    "mode=0755,uid=0,gid=0"));
 +    // Disabled for Halium, mounted by LXC config
-+    //CHECKCALL(mount("tmpfs", "/apex", "tmpfs", MS_NOEXEC | MS_NOSUID | MS_NODEV,
-+    //                "mode=0755,uid=0,gid=0"));
++    if (is_recovery) {
++        CHECKCALL(mount("tmpfs", "/apex", "tmpfs", MS_NOEXEC | MS_NOSUID | MS_NODEV,
++                        "mode=0755,uid=0,gid=0"));
++    }
  
      // /debug_ramdisk is used to preserve additional files from the debug ramdisk
      CHECKCALL(mount("tmpfs", "/debug_ramdisk", "tmpfs", MS_NOEXEC | MS_NOSUID | MS_NODEV,
 -- 
-2.28.0
+2.32.0
 

--- a/system/core/0004-halium-avoid-modifying-USB-configuration-set-by-host.patch
+++ b/system/core/0004-halium-avoid-modifying-USB-configuration-set-by-host.patch
@@ -1,4 +1,4 @@
-From 97761ae4bcf2e821e4a0bb63d354478b5e02cb37 Mon Sep 17 00:00:00 2001
+From 75421b84c7656046492853370663e9b279d758ae Mon Sep 17 00:00:00 2001
 From: TheKit <nekit1000@gmail.com>
 Date: Sat, 19 Dec 2020 21:42:41 +0200
 Subject: [PATCH] (halium) avoid modifying USB configuration set by host
@@ -39,5 +39,5 @@ index 809044aaa..56c89344f 100644
      oneshot
      user root
 -- 
-2.28.0
+2.32.0
 

--- a/system/core/0005-halium-init-Handle-udev-event-peaks.patch
+++ b/system/core/0005-halium-init-Handle-udev-event-peaks.patch
@@ -1,4 +1,4 @@
-From 13f6fce463e161845446503f96d0a735c03dfcd5 Mon Sep 17 00:00:00 2001
+From 39b071305e7f3056abcfd222dcc58579ab3817e8 Mon Sep 17 00:00:00 2001
 From: Alfonso Sanchez-Beato <alfonso.sanchez-beato@canonical.com>
 Date: Mon, 15 Feb 2016 19:36:32 +0100
 Subject: [PATCH] (halium) init: Handle udev event peaks
@@ -16,7 +16,7 @@ Signed-off-by: Ondrej Kubik <ondrej.kubik@canonical.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/rootdir/ueventd.rc b/rootdir/ueventd.rc
-index 41ad5bd09..25e054174 100644
+index 451f5adf3..775af79dc 100644
 --- a/rootdir/ueventd.rc
 +++ b/rootdir/ueventd.rc
 @@ -1,5 +1,5 @@
@@ -27,5 +27,5 @@ index 41ad5bd09..25e054174 100644
  subsystem graphics
      devname uevent_devpath
 -- 
-2.28.0
+2.32.0
 

--- a/system/core/0006-halium-init-ignore-non-kernel-messages-in-ReadUevent.patch
+++ b/system/core/0006-halium-init-ignore-non-kernel-messages-in-ReadUevent.patch
@@ -1,4 +1,4 @@
-From 7d094446c1bb707b8cd476158c9197daec542dca Mon Sep 17 00:00:00 2001
+From a7b5fa7924217e30c1aad96694feadabf05ac644 Mon Sep 17 00:00:00 2001
 From: NeKit <nekit1000@gmail.com>
 Date: Sun, 19 Apr 2020 23:47:38 +0200
 Subject: [PATCH] (halium) init: ignore non-kernel messages in ReadUevent
@@ -15,7 +15,7 @@ Change-Id: Ib7e4521899035e2dc67efaf27fc1bea13659efb4
  1 file changed, 13 insertions(+), 1 deletion(-)
 
 diff --git a/init/uevent_listener.cpp b/init/uevent_listener.cpp
-index 26f7ed6a9..f63c1d6c9 100644
+index 62cd2be3a..6493c56c0 100644
 --- a/init/uevent_listener.cpp
 +++ b/init/uevent_listener.cpp
 @@ -99,7 +99,19 @@ bool UeventListener::ReadUevent(Uevent* uevent) const {
@@ -40,5 +40,5 @@ index 26f7ed6a9..f63c1d6c9 100644
          }
          return false;
 -- 
-2.28.0
+2.32.0
 


### PR DESCRIPTION
We modified first stage init for Anbox and Halium, which
unfortunately changes the behavior expected by the
recovery.

This commit modifies 0001 and 0003 to keep the original
behavior expected by the recovery and regenerates all
patch files.

Change-Id: I4b61c01ea1882f54791012f8b74035c68cf44a23
Signed-off-by: Alexander Martinz <alex@amartinz.at>