### PR TITLE
build/soong: Update Xcode enablement

### DIFF
--- a/build/soong/0002-x86_darwin_host-Allow-building-with-macOS-11.3-SDK.patch
+++ b/build/soong/0002-x86_darwin_host-Allow-building-with-macOS-11.3-SDK.patch
@@ -1,24 +1,28 @@
-From 90a40ef6780af219fc0ef1ea6052a5241333daba Mon Sep 17 00:00:00 2001
+From 03d89ff3b832fd03a49240879cfab0ae537ce115 Mon Sep 17 00:00:00 2001
 From: Alfred Neumayer <dev.beidl@gmail.com>
 Date: Thu, 24 Jun 2021 19:46:44 +0200
-Subject: [PATCH] x86_darwin_host: Allow building with macOS 11.3 SDK
+Subject: [PATCH] x86_darwin_host: Allow building with macOS SDK 11.3 to 12.3
 
-This enables building with Xcode 12.5 installed.
+This enables building with newer Xcode installed.
 
 Change-Id: Ib68b631e95d154bdc1805facf5400e8f9d4c9d54
 ---
- cc/config/x86_darwin_host.go | 1 +
- 1 file changed, 1 insertion(+)
+ cc/config/x86_darwin_host.go | 5 +++++
+ 1 file changed, 5 insertions(+)
 
 diff --git a/cc/config/x86_darwin_host.go b/cc/config/x86_darwin_host.go
-index 52d63514..1c7eb4ec 100644
+index 52d6351..d831943 100644
 --- a/cc/config/x86_darwin_host.go
 +++ b/cc/config/x86_darwin_host.go
-@@ -83,6 +83,7 @@ var (
+@@ -83,6 +83,11 @@ var (
  		"10.12",
  		"10.13",
  		"10.14",
 +		"11.3",
++		"12.0",
++		"12.1",
++		"12.2",
++		"12.3",
  	}
  
  	darwinAvailableLibraries = append(


### PR DESCRIPTION
Apple decides to change their equivalent of a framework more often now,
so add a bunch of potential future versions of the SDK to the list.

This allows macOS Monterey (12.0) and its minor updates to be used for building Halium.