### PR TITLE
(halium) healthd: Shut down using sys.powerctl in charger mode

### DIFF
--- a/system/core/0047-halium-healthd-Shut-down-using-sys.powerctl-in-charg.patch
+++ b/system/core/0047-halium-healthd-Shut-down-using-sys.powerctl-in-charg.patch
@@ -1,0 +1,39 @@
+From 977da26224f7275e7c4d25599aaac31c152a0ee3 Mon Sep 17 00:00:00 2001
+From: Alfred Neumayer <dev.beidl@gmail.com>
+Date: Sun, 12 Dec 2021 10:47:47 +0100
+Subject: [PATCH] (halium) healthd: Shut down using sys.powerctl in charger
+ mode
+
+Since Halium runs in a container, it is not properly guaranteed to
+handle reboots properly. Turns out that on the Pixel 3a it spams
+the kernel log with following messages:
+
+ init: Failed to initialize property area
+
+This might be because the filesystem is from the old instance.
+
+Since init is running and is able to exit cleanly, let's just
+trigger that. The host side will notice the shutdown and cause
+a proper reboot, so it's done by the ultimate authority anyway.
+
+Change-Id: I3674a6df1126ffee8da85aa9f75620a3f3bb6813
+---
+ healthd/healthd_mode_charger.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/healthd/healthd_mode_charger.cpp b/healthd/healthd_mode_charger.cpp
+index 56a9f86..cb5acd4 100644
+--- a/healthd/healthd_mode_charger.cpp
++++ b/healthd/healthd_mode_charger.cpp
+@@ -434,7 +434,7 @@ static void process_key(charger* charger, int code, int64_t now) {
+                 } else {
+                     if (charger->batt_anim->cur_level >= charger->boot_min_cap) {
+                         LOGW("[%" PRId64 "] rebooting\n", now);
+-                        reboot(RB_AUTOBOOT);
++                        property_set("sys.powerctl", "shutdown");
+                     } else {
+                         LOGV("[%" PRId64
+                              "] ignore power-button press, battery level "
+-- 
+2.30.1 (Apple Git-130)
+


### PR DESCRIPTION
Since Halium runs in a container, it is not properly guaranteed to
handle reboots properly. Turns out that on the Pixel 3a it spams
the kernel log with following messages:

 init: Failed to initialize property area

This might be because the filesystem is from the old instance.

Since init is running and is able to exit cleanly, let's just
trigger that. The host side will notice the shutdown and cause
a proper reboot, so it's done by the ultimate authority anyway.