### PR TITLE
Remove libdl-static from being a requirement for static gpg

### DIFF
--- a/external/gpg/0001-Remove-libdl-static-from-being-a-requirement-for-sta.patch
+++ b/external/gpg/0001-Remove-libdl-static-from-being-a-requirement-for-sta.patch
@@ -1,0 +1,54 @@
+From b006a1581e07af85e0466362cf6b6c8b2dc36efb Mon Sep 17 00:00:00 2001
+From: Florian Leeber <florian@ubports.com>
+Date: Wed, 5 Jan 2022 22:13:58 +0100
+Subject: [PATCH] Remove libdl-static from being a requirement for static gpg
+
+Change-Id: I07ab588c3d08d2fb0e016adb94c646e6539b86cb
+---
+ Android.mk     | 16 ----------------
+ g10/Android.mk |  2 +-
+ 2 files changed, 1 insertion(+), 17 deletions(-)
+
+diff --git a/Android.mk b/Android.mk
+index 90a99c8..04c9313 100644
+--- a/Android.mk
++++ b/Android.mk
+@@ -3,22 +3,6 @@
+ LOCAL_PATH:=$(call my-dir)
+ gpg_local_path := $(LOCAL_PATH)
+ 
+-#
+-# build static version of libdl from bionics
+-#
+-
+-include $(CLEAR_VARS)
+-LOCAL_LDFLAGS := -Wl,--exclude-libs=libgcc.a
+-# for x86, exclude libgcc_eh.a for the same reasons as above
+-ifeq ($(TARGET_ARCH),x86)
+-LOCAL_LDFLAGS += -Wl,--exclude-libs=libgcc_eh.a
+-endif
+-LOCAL_SRC_FILES:= ../../bionic/libdl/libdl.cpp
+-LOCAL_MODULE:= libdl-static
+-LOCAL_ADDITIONAL_DEPENDENCIES := $(LOCAL_PATH)/Android.mk
+-LOCAL_ALLOW_UNDEFINED_SYMBOLS := true
+-include $(BUILD_STATIC_LIBRARY)
+-
+ # gpg
+ include $(CLEAR_VARS)
+ 
+diff --git a/g10/Android.mk b/g10/Android.mk
+index 12b1a5b..6aafa97 100644
+--- a/g10/Android.mk
++++ b/g10/Android.mk
+@@ -81,7 +81,7 @@ LOCAL_CFLAGS := \
+ LOCAL_CFLAGS += -DHAVE_CONFIG_H -Wno-error
+ 
+ LOCAL_STATIC_LIBRARIES += libgpgcipher libgpgutil libgpgmpi libgpgintl libgpgcompat
+-LOCAL_STATIC_LIBRARIES += libc libz libdl-static
++LOCAL_STATIC_LIBRARIES += libc libz
+ 
+ LOCAL_MODULE:= static_gpg
+ LOCAL_MODULE_CLASS := RECOVERY_EXECUTABLES
+-- 
+2.17.1
+


### PR DESCRIPTION
This actually is an interesting one, for some reason only on armhf the libdl static library is no longer needed in static gpg build, since external/libunwind_llvm is now built without requiring this anymore.

This will fix the ugly error with __aeabi_unwind_cpp_pr0:

```
prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/arm-linux-androideabi/bin/ld: error: /home/florian/porting/hammerhead-9.0/out/target/product/hammerhead/obj/STATIC_LIBRARIES/libunwind_llvm_intermediates/libunwind_llvm.a(Unwind-EHABI.o): multiple definition of '__aeabi_unwind_cpp_pr0'
prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/arm-linux-androideabi/bin/ld: /home/florian/porting/hammerhead-9.0/out/target/product/hammerhead/obj/STATIC_LIBRARIES/libdl-static_intermediates/libdl-static.a(libdl.o): previous definition here
```

Change-Id: Ic57ce3df66c6e6e38573d1a09d2e7dd4d7d6daae