### PR TITLE
(halium) libcameraservice: Forward-port trust-store integration

### DIFF
--- a/frameworks/av/0006-Adjust-permissions-of-socket.-Provides-a-connection-.patch
+++ b/frameworks/av/0006-Adjust-permissions-of-socket.-Provides-a-connection-.patch
@@ -1,0 +1,251 @@
+From 604eb83b30d3ab8d8133969af1052d597dc22137 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Thomas=20Vo=C3=9F?= <thomas.voss@canonical.com>
+Date: Wed, 30 Jul 2014 23:08:00 +0200
+Subject: [PATCH 1/2] Adjust permissions of socket. Provides a connection to a
+ per-user remote trust-store implementation via a unix domain socket.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Adjusts the connect behavior to reject a connection by an app if the application has not been trusted by the user.
+
+Change-Id: I4938ed9d004dee44422867ac5b3d204508bc2a00
+Signed-off-by: Thomas Voß <thomas.voss@canonical.com>
+Signed-off-by: Ricardo Salveti de Araujo <rsalveti@rsalveti.net>
+Signed-off-by: Thomas Voß <thomas.voss@canonical.com>
+---
+ .../camera/libcameraservice/CameraService.cpp | 203 ++++++++++++++++++
+ 1 file changed, 203 insertions(+)
+
+diff --git a/services/camera/libcameraservice/CameraService.cpp b/services/camera/libcameraservice/CameraService.cpp
+index d76ad1dad7..b35ac53520 100644
+--- a/services/camera/libcameraservice/CameraService.cpp
++++ b/services/camera/libcameraservice/CameraService.cpp
+@@ -58,7 +58,9 @@
+ #include <mediautils/BatteryNotifier.h>
+ #include <sensorprivacy/SensorPrivacyManager.h>
+ #include <utils/Errors.h>
++#include <utils/KeyedVector.h>
+ #include <utils/Log.h>
++#include <utils/Looper.h>
+ #include <utils/String16.h>
+ #include <utils/SystemClock.h>
+ #include <utils/Trace.h>
+@@ -82,6 +84,202 @@ namespace {
+     const char* kPermissionServiceName = "permission";
+ }; // namespace anonymous
+ 
++#include <stdint.h>
++
++#include <sys/socket.h>
++#include <sys/stat.h>
++#include <sys/types.h>
++#include <sys/un.h>
++
++namespace
++{
++// Please see lp:trust-store and
++//   http://bazaar.launchpad.net/~thomas-voss/trust-store/add-trust-stored/view/head:/tests/remote_agent_test.cpp#L538
++// for a test-case illustrating the setup and the "other side" we
++// are talking to here.
++struct TrustAgentRegistry : public android::Thread,
++                            public android::LooperCallback
++{
++    // The request we sent out via a socket to a remote agent.
++    struct Request
++    {
++        uid_t uid; pid_t pid; ::uint64_t feature; ::int64_t startTime;
++    };
++
++    enum Answer
++    {
++        denied = 0,
++        granted = 1
++    };
++
++    TrustAgentRegistry(const char* endpoint)
++            : android::Thread(false),
++              looper(new android::Looper(false))
++    {
++        static const int socketErrorCode = -1;
++
++        // We create a unix domain socket
++        socketFd = ::socket(PF_UNIX, SOCK_STREAM, 0);
++
++        if (socketFd == socketErrorCode)
++        {
++            ALOGE("Could not create unix stream socket");
++            return;
++        }
++
++        // Prepare for binding to endpoint in file system.
++        // Consciously ignoring errors here.
++        ::unlink(endpoint);
++
++        // Setup address
++        sockaddr_un address;
++        ::memset(&address, 0, sizeof(sockaddr_un));
++
++        address.sun_family = AF_UNIX;
++        ::strncpy(address.sun_path, endpoint, 108);
++
++        // And bind to the endpoint in the filesystem.
++        static const int bindErrorCode = -1;
++        int rc = ::bind(socketFd, reinterpret_cast<sockaddr*>(&address), sizeof(sockaddr_un));        
++
++        if (rc == bindErrorCode)
++        {
++            ALOGE("Could not bind to endpoint");
++            return;
++        }
++
++        // Ensure correct permissions
++        static const int chmodErrorCode = -1;
++        rc = ::chmod(endpoint, S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IWGRP | S_IXGRP);
++
++        if (rc == chmodErrorCode)
++        {
++            ALOGE("Could not adjust permissions of endpoint");
++            return;
++        }
++
++        // Start listening for incoming connections.
++        static const int listenErrorCode = -1;
++        static const int backLogSize = 5;
++
++        rc = ::listen(socketFd, backLogSize);
++
++        if (rc == listenErrorCode)
++        {
++            ALOGE("Could not start listening for incoming connections");
++            return;
++        }
++
++        looper->addFd(socketFd,
++                      ALOOPER_POLL_CALLBACK,
++                      ALOOPER_EVENT_INPUT |
++                      ALOOPER_EVENT_ERROR |
++                      ALOOPER_EVENT_INVALID,
++                      android::sp<android::LooperCallback>(this),
++                      NULL);
++
++        run("TrustAgentRegistry");
++    }
++
++    ~TrustAgentRegistry()
++    {
++        looper->removeFd(socketFd);
++        requestExitAndWait();
++    }
++
++    // From android::LooperCallback
++    int handleEvent(int fd, int events, void*)
++    {
++        static const int keepOn = 1;
++        static const int bailOut = 0;
++
++        if (fd != socketFd)
++            return keepOn;
++
++        if (events & ALOOPER_EVENT_ERROR)
++            return bailOut;
++
++        if (events & ALOOPER_EVENT_INVALID)
++            return bailOut;
++
++        // Error code when accepting connections.
++        static const int acceptErrorCode = -1;
++
++        // Error code when querying socket options.
++        static const int getSockOptError = -1;
++        // Some state we preserve across loop iterations.
++        sockaddr_un address;
++        socklen_t addressLength = sizeof(sockaddr_un);
++
++        ucred peerCredentials; ::memset(&peerCredentials, 0, sizeof(ucred));
++        socklen_t len = sizeof(peerCredentials);
++
++        int connectionFd = ::accept(socketFd, reinterpret_cast<sockaddr*>(&address), &addressLength);
++
++        if (connectionFd == acceptErrorCode)
++            return keepOn;
++
++        // We query the peer credentials
++        len = sizeof(ucred);
++        int rc = ::getsockopt(connectionFd, SOL_SOCKET, SO_PEERCRED, &peerCredentials, &len);
++        if (rc == getSockOptError)
++        {
++            ALOGE("Could not query peer credentials");
++        } else
++        {
++            android::AutoMutex am(remoteAgentsGuard);
++            remoteAgents.add(peerCredentials.uid, connectionFd);
++        }
++
++        return keepOn;
++    }
++
++    // From android::Thread
++    bool threadLoop()
++    {
++        static const int timeoutInMs = 5000;
++
++        looper->pollOnce(timeoutInMs);
++
++        return exitPending();
++    }
++
++    bool verifyConnectRequestFor(uid_t uid, pid_t pid)
++    {
++        int socket = -1;
++
++        // Scoping access to the known remoteAgents here.
++        {
++            android::AutoMutex am(remoteAgentsGuard);
++            ssize_t idx = remoteAgents.indexOfKey(uid);
++            if (idx == -1)
++                return false;
++
++            socket = remoteAgents.keyAt(idx);
++        }
++
++        Request request; request.uid = uid; request.pid = pid; request.feature = 0; request.startTime = -1;
++
++        if (::write(socket, &request, sizeof(Request)) == -1)
++            return false;
++
++        int32_t answerFromSocket = denied;
++
++        if (::read(socket, &answerFromSocket, sizeof(::int32_t)) == -1)
++            return false;
++
++        return answerFromSocket == granted;
++    }
++
++    int socketFd;
++    android::sp<android::Looper> looper;
++    android::Mutex remoteAgentsGuard;
++    android::KeyedVector<uid_t, int> remoteAgents;
++};
++
++android::sp<TrustAgentRegistry> trust_agent_registry(new TrustAgentRegistry("/dev/socket/camera_service/camera_service_to_trust"));
++}
++
+ namespace android {
+ 
+ using base::StringPrintf;
+@@ -980,6 +1178,11 @@ Status CameraService::validateClientPermissionsLocked(const String8& cameraId,
+     // Check if we can trust clientUid
+     if (clientUid == USE_CALLING_UID) {
+         clientUid = callingUid;
++        // We try to reach out to a remote trust store instance to
++        // verify that the app with uid and pid is allowed to access the
++        // camera.
++        if (!trust_agent_registry->verifyConnectRequestFor(clientUid, callingPid))
++            return PERMISSION_DENIED;
+     } else if (!isTrustedCallingUid(callingUid)) {
+         ALOGE("CameraService::connect X (calling PID %d, calling UID %d) rejected "
+                 "(don't trust clientUid %d)", callingPid, callingUid, clientUid);
+-- 
+2.35.0.rc2
+

--- a/frameworks/av/0007-Fix-bugs-and-add-traces-for-trust-store-support.patch
+++ b/frameworks/av/0007-Fix-bugs-and-add-traces-for-trust-store-support.patch
@@ -1,0 +1,169 @@
+From 66bfb012fe1a8f6973e5bbef53f320dd7597c775 Mon Sep 17 00:00:00 2001
+From: Alfonso Sanchez-Beato <alfonso.sanchez-beato@canonical.com>
+Date: Thu, 13 Aug 2015 19:03:29 +0200
+Subject: [PATCH 2/2] Fix bugs and add traces for trust-store support
+
+Change-Id: I774d73d1cf8a05e5704e62736a155cac2edcd8ab
+---
+ .../camera/libcameraservice/CameraService.cpp | 64 ++++++++++++++++---
+ 1 file changed, 56 insertions(+), 8 deletions(-)
+
+diff --git a/services/camera/libcameraservice/CameraService.cpp b/services/camera/libcameraservice/CameraService.cpp
+index b35ac53520..013edf1aa2 100644
+--- a/services/camera/libcameraservice/CameraService.cpp
++++ b/services/camera/libcameraservice/CameraService.cpp
+@@ -21,15 +21,19 @@
+ #include <algorithm>
+ #include <climits>
+ #include <stdio.h>
++#include <errno.h>
++#include <string.h>
+ #include <cstring>
+ #include <ctime>
+ #include <string>
++#include <fstream>
+ #include <sys/types.h>
+ #include <inttypes.h>
+ #include <pthread.h>
+ 
+ #include <android/hardware/ICamera.h>
+ #include <android/hardware/ICameraClient.h>
++#include <android/looper.h>
+ 
+ #include <android-base/macros.h>
+ #include <android-base/parseint.h>
+@@ -118,6 +122,19 @@ struct TrustAgentRegistry : public android::Thread,
+     {
+         static const int socketErrorCode = -1;
+ 
++        {
++            // Keep this disabled for distros which don't carry the necessary kernel patch
++            enabled = false;
++
++            std::ifstream kernelSetting;
++            kernelSetting.open("/sys/module/binder/parameters/global_pid_lookups", std::ifstream::in);
++            if (kernelSetting.is_open()) {
++                std::string param;
++                kernelSetting >> param;
++                enabled = (param.find("Y") == 0);
++            }
++        }
++
+         // We create a unix domain socket
+         socketFd = ::socket(PF_UNIX, SOCK_STREAM, 0);
+ 
+@@ -140,7 +157,7 @@ struct TrustAgentRegistry : public android::Thread,
+ 
+         // And bind to the endpoint in the filesystem.
+         static const int bindErrorCode = -1;
+-        int rc = ::bind(socketFd, reinterpret_cast<sockaddr*>(&address), sizeof(sockaddr_un));        
++        int rc = ::bind(socketFd, reinterpret_cast<sockaddr*>(&address), sizeof(sockaddr_un));
+ 
+         if (rc == bindErrorCode)
+         {
+@@ -193,6 +210,8 @@ struct TrustAgentRegistry : public android::Thread,
+         static const int keepOn = 1;
+         static const int bailOut = 0;
+ 
++        ALOGD("%s", __PRETTY_FUNCTION__);
++
+         if (fd != socketFd)
+             return keepOn;
+ 
+@@ -227,6 +246,7 @@ struct TrustAgentRegistry : public android::Thread,
+             ALOGE("Could not query peer credentials");
+         } else
+         {
++            ALOGD("%s adding uid %d fd %d", __PRETTY_FUNCTION__, peerCredentials.uid, connectionFd);
+             android::AutoMutex am(remoteAgentsGuard);
+             remoteAgents.add(peerCredentials.uid, connectionFd);
+         }
+@@ -237,9 +257,17 @@ struct TrustAgentRegistry : public android::Thread,
+     // From android::Thread
+     bool threadLoop()
+     {
+-        static const int timeoutInMs = 5000;
++        static const int timeoutInMs = -1;
++        int res;
+ 
+-        looper->pollOnce(timeoutInMs);
++        ALOGD("%s start", __PRETTY_FUNCTION__);
++
++        do {
++            res = looper->pollOnce(timeoutInMs);
++            ALOGD("%s res %d", __PRETTY_FUNCTION__, res);
++        } while(res != ALOOPER_POLL_ERROR);
++
++        ALOGD("%s exit", __PRETTY_FUNCTION__);
+ 
+         return exitPending();
+     }
+@@ -248,25 +276,40 @@ struct TrustAgentRegistry : public android::Thread,
+     {
+         int socket = -1;
+ 
++        // If the kernel features are not enabled just let the request through.
++        // For distros which don't ship the necessary kernel patch.
++        if (!enabled)
++            return true;
++
++        ALOGD("%s uid %d pid %d", __PRETTY_FUNCTION__, uid, pid);
++
+         // Scoping access to the known remoteAgents here.
+         {
+             android::AutoMutex am(remoteAgentsGuard);
+             ssize_t idx = remoteAgents.indexOfKey(uid);
+-            if (idx == -1)
++            if (idx < 0) {
++                ALOGE("No trust store connection found for user %d", uid);
+                 return false;
++            }
+ 
+-            socket = remoteAgents.keyAt(idx);
++            socket = remoteAgents[idx];
+         }
+ 
+         Request request; request.uid = uid; request.pid = pid; request.feature = 0; request.startTime = -1;
+ 
+-        if (::write(socket, &request, sizeof(Request)) == -1)
++        if (::write(socket, &request, sizeof(Request)) == -1) {
++            ALOGE("%s write error: %s (%d)", __PRETTY_FUNCTION__, strerror(errno), errno);
+             return false;
++        }
+ 
+         int32_t answerFromSocket = denied;
+ 
+-        if (::read(socket, &answerFromSocket, sizeof(::int32_t)) == -1)
++        if (::read(socket, &answerFromSocket, sizeof(::int32_t)) == -1) {
++            ALOGE("%s read error: %s (%d)", __PRETTY_FUNCTION__, strerror(errno), errno);
+             return false;
++        }
++
++        ALOGD("%s answerFromSocket %d", __PRETTY_FUNCTION__, answerFromSocket);
+ 
+         return answerFromSocket == granted;
+     }
+@@ -275,6 +318,7 @@ struct TrustAgentRegistry : public android::Thread,
+     android::sp<android::Looper> looper;
+     android::Mutex remoteAgentsGuard;
+     android::KeyedVector<uid_t, int> remoteAgents;
++    bool enabled;
+ };
+ 
+ android::sp<TrustAgentRegistry> trust_agent_registry(new TrustAgentRegistry("/dev/socket/camera_service/camera_service_to_trust"));
+@@ -1182,7 +1226,11 @@ Status CameraService::validateClientPermissionsLocked(const String8& cameraId,
+         // verify that the app with uid and pid is allowed to access the
+         // camera.
+         if (!trust_agent_registry->verifyConnectRequestFor(clientUid, callingPid))
+-            return PERMISSION_DENIED;
++            return STATUS_ERROR_FMT(ERROR_PERMISSION_DENIED,
++                    "Untrusted caller (calling PID %d, UID %d) trying to "
++                    "forward camera access to camera %s for client %s (PID %d, UID %d)",
++                    callingPid, callingUid, cameraId.string(),
++                    clientName8.string(), clientUid, clientPid);
+     } else if (!isTrustedCallingUid(callingUid)) {
+         ALOGE("CameraService::connect X (calling PID %d, calling UID %d) rejected "
+                 "(don't trust clientUid %d)", callingPid, callingUid, clientUid);
+-- 
+2.35.0.rc2
+

--- a/system/core/0010-halium-init.rc-Create-directory-for-trust-store-sock.patch
+++ b/system/core/0010-halium-init.rc-Create-directory-for-trust-store-sock.patch
@@ -1,0 +1,32 @@
+From 55b620a99c15182a81eef6f39fb4de2cb0e30f70 Mon Sep 17 00:00:00 2001
+From: Alfred Neumayer <dev.beidl@gmail.com>
+Date: Sun, 12 Dec 2021 17:24:57 +0100
+Subject: [PATCH] (halium) init.rc: Create directory for trust-store socket
+
+This enables the minimediaservice process to create the socket
+in a well-known location for consumption by trust-store.
+
+Change-Id: Iac114c1b0d92afb54d39ad314c6b521d6c088dc1
+---
+ rootdir/init.rc | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/rootdir/init.rc b/rootdir/init.rc
+index d5afabce86..0886a658d0 100644
+--- a/rootdir/init.rc
++++ b/rootdir/init.rc
+@@ -298,6 +298,11 @@ on init
+     chmod 0660 /sys/power/wake_lock
+     chmod 0660 /sys/power/wake_unlock
+ 
++    # Create directory necessary for the CameraService trust-store socket
++    mkdir /dev/socket/camera_service
++    chown root camera /dev/socket/camera_service
++    chmod 0775 /dev/socket/camera_service
++
+     # Start logd before any other services run to ensure we capture all of their logs.
+     start logd
+ 
+-- 
+2.35.0.rc2
+


### PR DESCRIPTION
Based on Canonical's phablet_4.2.2 tree as described here:
https://github.com/ubports/ubuntu-touch/issues/1821

This enables the host-side to connect to a socket on the Halium
container side (spawned by minimediaservice) for the purpose
of checking camera permissions interactively, using a dialog.