### PR TITLE
(halium) hardware/qcom/audio: Refresh volume patch

### DIFF
--- a/hardware/qcom/audio/default/0001-hal-msm8974-Use-64bit-types-to-request-mute-volume-c.patch
+++ b/hardware/qcom/audio/default/0001-hal-msm8974-Use-64bit-types-to-request-mute-volume-c.patch
@@ -1,7 +1,8 @@
-From 84a5856fe86101ecf809024e04e4ef9afb9e6e50 Mon Sep 17 00:00:00 2001
+From 2f48f20a360b74b8b2458ee051af80a5d307fa3f Mon Sep 17 00:00:00 2001
 From: Alfred Neumayer <dev.beidl@gmail.com>
 Date: Sun, 8 Aug 2021 18:32:18 +0200
-Subject: [PATCH] hal/msm8974: Use 64bit types to request mute & volume changes
+Subject: [PATCH 1/2] hal/msm8974: Use 64bit types to request mute & volume
+ changes
 
 64bit kernels fail to apply mute & volume requests from userspace
 when the sizes don't match, since they can't be parsed.
@@ -10,8 +11,8 @@ Turn them into 64bit types instead.
 Change-Id: I934f6a77147a56b43450d595e93e1f3cddea533f
 ---
  hal/Android.mk         |  2 +-
- hal/msm8974/platform.c | 10 +++++-----
- 2 files changed, 6 insertions(+), 6 deletions(-)
+ hal/msm8974/platform.c | 14 ++++++++------
+ 2 files changed, 9 insertions(+), 7 deletions(-)
 
 diff --git a/hal/Android.mk b/hal/Android.mk
 index 88dbbe5..d1d804b 100644
@@ -27,19 +28,29 @@ index 88dbbe5..d1d804b 100644
  LOCAL_CFLAGS += -Werror
  
 diff --git a/hal/msm8974/platform.c b/hal/msm8974/platform.c
-index 5a36f0c..86d782a 100644
+index 5a36f0c..0b89548 100644
 --- a/hal/msm8974/platform.c
 +++ b/hal/msm8974/platform.c
-@@ -2440,7 +2440,7 @@ int platform_set_voice_volume(void *platform, int volume)
+@@ -2440,14 +2440,16 @@ int platform_set_voice_volume(void *platform, int volume)
      const char *mixer_ctl_name = "Voice Rx Gain";
      const char *mute_mixer_ctl_name = "Voice Rx Device Mute";
      int vol_index = 0, ret = 0;
 -    uint32_t set_values[ ] = {0,
++    float gain_factor;
 +    long int set_values[ ] = {0,
                                ALL_SESSION_VSID,
                                DEFAULT_VOLUME_RAMP_DURATION_MS};
  
-@@ -2456,7 +2456,7 @@ int platform_set_voice_volume(void *platform, int volume)
+     // Voice volume levels are mapped to adsp volume levels as follows.
+     // 100 -> 5, 80 -> 4, 60 -> 3, 40 -> 2, 20 -> 1  0 -> 0
+     // But this values don't changed in kernel. So, below change is need.
+-    vol_index = (int)percent_to_index(volume, MIN_VOL_INDEX, my_data->max_vol_index);
++    gain_factor = ((float)volume)/100.0f;
++    vol_index = (int)(my_data->max_vol_index * gain_factor);
+     set_values[0] = vol_index;
+ 
+     ctl = mixer_get_ctl_by_name(adev->mixer, mixer_ctl_name);
+@@ -2456,7 +2458,7 @@ int platform_set_voice_volume(void *platform, int volume)
                __func__, mixer_ctl_name);
          return -EINVAL;
      }
@@ -48,7 +59,7 @@ index 5a36f0c..86d782a 100644
      mixer_ctl_set_array(ctl, set_values, ARRAY_SIZE(set_values));
  
      // Send mute command in case volume index is max since indexes are inverted
-@@ -2474,7 +2474,7 @@ int platform_set_voice_volume(void *platform, int volume)
+@@ -2474,7 +2476,7 @@ int platform_set_voice_volume(void *platform, int volume)
                __func__, mute_mixer_ctl_name);
          return -EINVAL;
      }
@@ -57,7 +68,7 @@ index 5a36f0c..86d782a 100644
      mixer_ctl_set_array(ctl, set_values, ARRAY_SIZE(set_values));
  
      if (my_data->csd != NULL) {
-@@ -2494,7 +2494,7 @@ int platform_set_mic_mute(void *platform, bool state)
+@@ -2494,7 +2496,7 @@ int platform_set_mic_mute(void *platform, bool state)
      struct mixer_ctl *ctl;
      const char *mixer_ctl_name = "Voice Tx Mute";
      int ret = 0;
@@ -66,7 +77,7 @@ index 5a36f0c..86d782a 100644
                                ALL_SESSION_VSID,
                                DEFAULT_MUTE_RAMP_DURATION_MS};
  
-@@ -2532,7 +2532,7 @@ int platform_set_device_mute(void *platform, bool state, char *dir)
+@@ -2532,7 +2534,7 @@ int platform_set_device_mute(void *platform, bool state, char *dir)
      struct mixer_ctl *ctl;
      char *mixer_ctl_name = NULL;
      int ret = 0;
@@ -76,5 +87,5 @@ index 5a36f0c..86d782a 100644
                                0};
      if(dir == NULL) {
 -- 
-2.30.1 (Apple Git-130)
+2.32.0 (Apple Git-132)
 

--- a/hardware/qcom/audio/default/0002-msm8974-Allow-speaker-phone-in-combination-with-hand.patch
+++ b/hardware/qcom/audio/default/0002-msm8974-Allow-speaker-phone-in-combination-with-hand.patch
@@ -1,7 +1,8 @@
-From e811adb3164e6841cec473e98e5a233b36208995 Mon Sep 17 00:00:00 2001
+From d89eed6f9728ead5a5f4976a6c3d037fbf3dd2b5 Mon Sep 17 00:00:00 2001
 From: Alfred Neumayer <dev.beidl@gmail.com>
 Date: Sun, 9 Jan 2022 14:38:12 +0100
-Subject: [PATCH] msm8974: Allow speaker phone in combination with handset mic
+Subject: [PATCH 2/2] msm8974: Allow speaker phone in combination with handset
+ mic
 
 On devices like the Pixel 3a something related to Fluence is
 causing trouble with speaker phone cancellation and quality.
@@ -18,7 +19,7 @@ Change-Id: Ifa29441771c829ea3bc14aea68f2ca504f7d9afc
  1 file changed, 10 insertions(+), 1 deletion(-)
 
 diff --git a/hal/msm8974/platform.c b/hal/msm8974/platform.c
-index 86d782a..786f417 100644
+index 0b89548..fd3e56b 100644
 --- a/hal/msm8974/platform.c
 +++ b/hal/msm8974/platform.c
 @@ -137,6 +137,7 @@ struct platform_data {
@@ -49,7 +50,7 @@ index 86d782a..786f417 100644
      // support max to mono, example if max count is 3, usecase supports Three, dual and mono mic
      switch (my_data->max_mic_count) {
          case 4:
-@@ -2941,7 +2948,9 @@ snd_device_t platform_get_input_snd_device(void *platform, audio_devices_t out_d
+@@ -2943,7 +2950,9 @@ snd_device_t platform_get_input_snd_device(void *platform, audio_devices_t out_d
                     out_device & AUDIO_DEVICE_OUT_SPEAKER_SAFE ||
                     out_device & AUDIO_DEVICE_OUT_WIRED_HEADPHONE ||
                     out_device & AUDIO_DEVICE_OUT_LINE) {


### PR DESCRIPTION
This includes a change to the voice call volume patch that
allows volume to be set linearly between 0 and max_vol_index.