### PR TITLE
[halium-11.0] Forward-port the recovery mounts patches and avoid mouting /apex tmpfs

### DIFF
--- a/system/core/0001-halium-init-start-inside-LXC-container-without-SELin.patch
+++ b/system/core/0001-halium-init-start-inside-LXC-container-without-SELin.patch
@@ -3,18 +3,23 @@ From: Asriel Dreemurr <asriel.danctnix@gmail.com>
 Date: Sun, 18 Oct 2020 00:31:45 +0700
 Subject: [PATCH] (halium) init: start inside LXC container without SELinux
 
+amartinz: keep first stage init setup for recovery, otherwise
+recovery will not boot.
+
+Signed-off-by: Alexander Martinz <alex@amartinz.at>
+Signed-off-by: Eugenio Paolantonio (g7) <me@medesimo.eu>
 ---
  init/Android.bp           |  2 ++
- init/first_stage_init.cpp | 32 +++++++++++++++++++++-----------
- init/init.cpp             | 10 +++++++---
- init/property_service.cpp | 24 +++++++++++++++---------
- init/service.cpp          | 10 ++++++----
+ init/first_stage_init.cpp | 49 ++++++++++++++++++++++++++++++---------
+ init/init.cpp             | 10 +++++---
+ init/property_service.cpp | 24 ++++++++++++-------
+ init/service.cpp          | 10 ++++----
  init/subcontext.cpp       |  3 ++-
- init/util.cpp             | 18 +++++++++++-------
- 7 files changed, 64 insertions(+), 35 deletions(-)
+ init/util.cpp             | 18 ++++++++------
+ 7 files changed, 81 insertions(+), 35 deletions(-)
 
 diff --git a/init/Android.bp b/init/Android.bp
-index e28d9f0..db7c8b8 100644
+index f292d689f..711d73735 100644
 --- a/init/Android.bp
 +++ b/init/Android.bp
 @@ -90,6 +90,7 @@ cc_defaults {
@@ -25,7 +30,7 @@ index e28d9f0..db7c8b8 100644
          "-Werror",
          "-Wthread-safety",
          "-DALLOW_FIRST_STAGE_CONSOLE=0",
-@@ -334,6 +335,7 @@ cc_binary {
+@@ -335,6 +336,7 @@ cc_binary {
          "-Wall",
          "-Wextra",
          "-Wno-unused-parameter",
@@ -34,68 +39,78 @@ index e28d9f0..db7c8b8 100644
      ],
      static_libs: [
 diff --git a/init/first_stage_init.cpp b/init/first_stage_init.cpp
-index 0215576..1b5bdb4 100644
+index 021557697..139768b63 100644
 --- a/init/first_stage_init.cpp
 +++ b/init/first_stage_init.cpp
-@@ -189,12 +189,14 @@ int FirstStageMain(int argc, char** argv) {
+@@ -189,21 +189,33 @@ int FirstStageMain(int argc, char** argv) {
      CHECKCALL(setenv("PATH", _PATH_DEFPATH, 1));
      // Get the basic filesystem setup we need put together in the initramdisk
      // on / and then we'll let the rc file figure out the rest.
 -    CHECKCALL(mount("tmpfs", "/dev", "tmpfs", MS_NOSUID, "mode=0755"));
 -    CHECKCALL(mkdir("/dev/pts", 0755));
+-    CHECKCALL(mkdir("/dev/socket", 0755));
+-    CHECKCALL(mount("devpts", "/dev/pts", "devpts", 0, NULL));
++
++    // We need to disable certain things for Anbox while the recovery needs it.
++    bool is_recovery = IsRecoveryMode();
 +
 +    // Disabled for Anbox, mounted by host system instead
-+    //CHECKCALL(mount("tmpfs", "/dev", "tmpfs", MS_NOSUID, "mode=0755"));
-+    //CHECKCALL(mkdir("/dev/pts", 0755));
-     CHECKCALL(mkdir("/dev/socket", 0755));
--    CHECKCALL(mount("devpts", "/dev/pts", "devpts", 0, NULL));
-+    //CHECKCALL(mount("devpts", "/dev/pts", "devpts", 0, NULL));
++    if (!is_recovery) {
++        mkdir("/dev/socket", 0755);
++    } else {
++        CHECKCALL(mount("tmpfs", "/dev", "tmpfs", MS_NOSUID, "mode=0755"));
++        CHECKCALL(mkdir("/dev/pts", 0755));
++        CHECKCALL(mkdir("/dev/socket", 0755));
++        CHECKCALL(mount("devpts", "/dev/pts", "devpts", 0, NULL));
  #define MAKE_STR(x) __STRING(x)
 -    CHECKCALL(mount("proc", "/proc", "proc", 0, "hidepid=2,gid=" MAKE_STR(AID_READPROC)));
-+    //CHECKCALL(mount("proc", "/proc", "proc", 0, "hidepid=2,gid=" MAKE_STR(AID_READPROC)));
++        CHECKCALL(mount("proc", "/proc", "proc", 0, "hidepid=2,gid=" MAKE_STR(AID_READPROC)));
  #undef MAKE_STR
++    }
      // Don't expose the raw commandline to unprivileged processes.
      CHECKCALL(chmod("/proc/cmdline", 0440));
-@@ -202,8 +204,9 @@ int FirstStageMain(int argc, char** argv) {
+     std::string cmdline;
      android::base::ReadFileToString("/proc/cmdline", &cmdline);
      gid_t groups[] = {AID_READPROC};
      CHECKCALL(setgroups(arraysize(groups), groups));
 -    CHECKCALL(mount("sysfs", "/sys", "sysfs", 0, NULL));
 -    CHECKCALL(mount("selinuxfs", "/sys/fs/selinux", "selinuxfs", 0, NULL));
 +    // Disabled for Anbox
-+    //CHECKCALL(mount("sysfs", "/sys", "sysfs", 0, NULL));
-+    //CHECKCALL(mount("selinuxfs", "/sys/fs/selinux", "selinuxfs", 0, NULL));
++    if (is_recovery) {
++        CHECKCALL(mount("sysfs", "/sys", "sysfs", 0, NULL));
++        CHECKCALL(mount("selinuxfs", "/sys/fs/selinux", "selinuxfs", 0, NULL));
++    }
  
      CHECKCALL(mknod("/dev/kmsg", S_IFCHR | 0600, makedev(1, 11)));
  
-@@ -215,8 +218,11 @@ int FirstStageMain(int argc, char** argv) {
+@@ -215,8 +227,14 @@ int FirstStageMain(int argc, char** argv) {
      CHECKCALL(mknod("/dev/urandom", S_IFCHR | 0666, makedev(1, 9)));
  
      // This is needed for log wrapper, which gets called before ueventd runs.
 -    CHECKCALL(mknod("/dev/ptmx", S_IFCHR | 0666, makedev(5, 2)));
 -    CHECKCALL(mknod("/dev/null", S_IFCHR | 0666, makedev(1, 3)));
 +    // Can be created by LXC on Anbox
-+    //CHECKCALL(mknod("/dev/ptmx", S_IFCHR | 0666, makedev(5, 2)));
-+    //CHECKCALL(mknod("/dev/null", S_IFCHR | 0666, makedev(1, 3)));
-+    mknod("/dev/ptmx", S_IFCHR | 0666, makedev(5, 2));
-+    mknod("/dev/null", S_IFCHR | 0666, makedev(1, 3));
++    if (is_recovery) {
++        CHECKCALL(mknod("/dev/ptmx", S_IFCHR | 0666, makedev(5, 2)));
++        CHECKCALL(mknod("/dev/null", S_IFCHR | 0666, makedev(1, 3)));
++    } else {
++        mknod("/dev/ptmx", S_IFCHR | 0666, makedev(5, 2));
++        mknod("/dev/null", S_IFCHR | 0666, makedev(1, 3));
++    }
  
      // These below mounts are done in first stage init so that first stage mount can mount
      // subdirectories of /mnt/{vendor,product}/.  Other mounts, not required by first stage mount,
-@@ -299,9 +305,10 @@ int FirstStageMain(int argc, char** argv) {
+@@ -299,7 +317,8 @@ int FirstStageMain(int argc, char** argv) {
          }
      }
  
 -    if (!DoFirstStageMount()) {
 +    // Disabled for Anbox
-+    /*if (!DoFirstStageMount()) {
++    if (is_recovery && !DoFirstStageMount()) {
          LOG(FATAL) << "Failed to mount required partitions early ...";
--    }
-+    }*/
+     }
  
-     struct stat new_root_info;
-     if (stat("/", &new_root_info) != 0) {
-@@ -318,8 +325,11 @@ int FirstStageMain(int argc, char** argv) {
+@@ -318,8 +337,16 @@ int FirstStageMain(int argc, char** argv) {
      setenv(kEnvFirstStageStartedAt, std::to_string(start_time.time_since_epoch().count()).c_str(),
             1);
  
@@ -103,13 +118,18 @@ index 0215576..1b5bdb4 100644
      const char* path = "/system/bin/init";
 -    const char* args[] = {path, "selinux_setup", nullptr};
 +    // Anbox: skip selinux_setup
-+    //const char* args[] = {path, "selinux_setup", nullptr};
-+    const char* args[] = {path, "second_stage", nullptr};
++    const char* next_stage;
++    if (is_recovery) {
++        next_stage = "selinux_setup";
++    } else {
++        next_stage = "second_stage";
++    }
++    const char* args[] = {path, next_stage, nullptr};
      auto fd = open("/dev/kmsg", O_WRONLY | O_CLOEXEC);
      dup2(fd, STDOUT_FILENO);
      dup2(fd, STDERR_FILENO);
 diff --git a/init/init.cpp b/init/init.cpp
-index ae8d23f..2c6eda8 100644
+index ae8d23fdf..2c6eda81d 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
 @@ -809,8 +809,10 @@ int SecondStageMain(int argc, char** argv) {
@@ -137,7 +157,7 @@ index ae8d23f..2c6eda8 100644
      // Don't mount filesystems or start core system services in charger mode.
      std::string bootmode = GetProperty("ro.bootmode", "");
 diff --git a/init/property_service.cpp b/init/property_service.cpp
-index 42dd5af..4b515d4 100644
+index 42dd5afcb..4b515d445 100644
 --- a/init/property_service.cpp
 +++ b/init/property_service.cpp
 @@ -132,7 +132,8 @@ void StopSendingMessages() {
@@ -209,7 +229,7 @@ index 42dd5af..4b515d4 100644
          const auto& cr = socket.cred();
          std::string error;
 diff --git a/init/service.cpp b/init/service.cpp
-index d6f913c..ec25684 100644
+index d6f913cca..ec25684e7 100644
 --- a/init/service.cpp
 +++ b/init/service.cpp
 @@ -242,9 +242,10 @@ void Service::SetProcessAttributesAndCaps() {
@@ -245,7 +265,7 @@ index d6f913c..ec25684 100644
      if (!AreRuntimeApexesReady() && !pre_apexd_) {
          // If this service is started before the Runtime and ART APEXes get
 diff --git a/init/subcontext.cpp b/init/subcontext.cpp
-index 9d4ea8c..628380e 100644
+index 9d4ea8cd3..628380e65 100644
 --- a/init/subcontext.cpp
 +++ b/init/subcontext.cpp
 @@ -212,7 +212,8 @@ void Subcontext::Fork() {
@@ -259,7 +279,7 @@ index 9d4ea8c..628380e 100644
                  PLOG(FATAL) << "Could not set execcon for '" << context_ << "'";
              }
 diff --git a/init/util.cpp b/init/util.cpp
-index 255434a..653b060 100644
+index 255434a1b..653b06002 100644
 --- a/init/util.cpp
 +++ b/init/util.cpp
 @@ -88,18 +88,20 @@ Result<uid_t> DecodeUid(const std::string& name) {

--- a/system/core/0003-halium-init-adjust-first-stage-mounts-for-Halium.patch
+++ b/system/core/0003-halium-init-adjust-first-stage-mounts-for-Halium.patch
@@ -8,7 +8,8 @@ Signed-off-by: Alexander Martinz <alex@amartinz.at>
 Signed-off-by: Eugenio Paolantonio (g7) <me@medesimo.eu>
 ---
  init/first_stage_init.cpp | 20 ++++++++++++++++----
- 1 file changed, 16 insertions(+), 4 deletions(-)
+ init/init.cpp             |  7 +++++--
+ 2 files changed, 21 insertions(+), 6 deletions(-)
 
 diff --git a/init/first_stage_init.cpp b/init/first_stage_init.cpp
 index 139768b63..4378000f4 100644
@@ -45,6 +46,24 @@ index 139768b63..4378000f4 100644
  
      // /debug_ramdisk is used to preserve additional files from the debug ramdisk
      CHECKCALL(mount("tmpfs", "/debug_ramdisk", "tmpfs", MS_NOEXEC | MS_NOSUID | MS_NODEV,
+diff --git a/init/init.cpp b/init/init.cpp
+index 2c6eda81d..ada8adf8a 100644
+--- a/init/init.cpp
++++ b/init/init.cpp
+@@ -644,8 +644,11 @@ static void MountExtraFilesystems() {
+     if ((x) != 0) PLOG(FATAL) << #x " failed.";
+ 
+     // /apex is used to mount APEXes
+-    CHECKCALL(mount("tmpfs", "/apex", "tmpfs", MS_NOEXEC | MS_NOSUID | MS_NODEV,
+-                    "mode=0755,uid=0,gid=0"));
++    // Disabled for Halium
++    if (IsRecoveryMode()) {
++        CHECKCALL(mount("tmpfs", "/apex", "tmpfs", MS_NOEXEC | MS_NOSUID | MS_NODEV,
++                        "mode=0755,uid=0,gid=0"));
++    }
+ 
+     // /linkerconfig is used to keep generated linker configuration
+     CHECKCALL(mount("tmpfs", "/linkerconfig", "tmpfs", MS_NOEXEC | MS_NOSUID | MS_NODEV,
 -- 
 2.33.0
 

--- a/system/core/0003-halium-init-adjust-first-stage-mounts-for-Halium.patch
+++ b/system/core/0003-halium-init-adjust-first-stage-mounts-for-Halium.patch
@@ -4,25 +4,17 @@ Date: Sat, 19 Dec 2020 21:39:09 +0200
 Subject: [PATCH] (halium) init: adjust first stage mounts for Halium
 
 Change-Id: I575e5f1072e69ffec9eea9adf96988f37f393018
+Signed-off-by: Alexander Martinz <alex@amartinz.at>
+Signed-off-by: Eugenio Paolantonio (g7) <me@medesimo.eu>
 ---
- init/first_stage_init.cpp | 15 ++++++++++-----
- 1 file changed, 10 insertions(+), 5 deletions(-)
+ init/first_stage_init.cpp | 20 ++++++++++++++++----
+ 1 file changed, 16 insertions(+), 4 deletions(-)
 
 diff --git a/init/first_stage_init.cpp b/init/first_stage_init.cpp
-index 1b5bdb4..1a9036e 100644
+index 139768b63..4378000f4 100644
 --- a/init/first_stage_init.cpp
 +++ b/init/first_stage_init.cpp
-@@ -193,7 +193,8 @@ int FirstStageMain(int argc, char** argv) {
-     // Disabled for Anbox, mounted by host system instead
-     //CHECKCALL(mount("tmpfs", "/dev", "tmpfs", MS_NOSUID, "mode=0755"));
-     //CHECKCALL(mkdir("/dev/pts", 0755));
--    CHECKCALL(mkdir("/dev/socket", 0755));
-+    //CHECKCALL(mkdir("/dev/socket", 0755));
-+    mkdir("/dev/socket", 0755);
-     //CHECKCALL(mount("devpts", "/dev/pts", "devpts", 0, NULL));
- #define MAKE_STR(x) __STRING(x)
-     //CHECKCALL(mount("proc", "/proc", "proc", 0, "hidepid=2,gid=" MAKE_STR(AID_READPROC)));
-@@ -229,14 +230,18 @@ int FirstStageMain(int argc, char** argv) {
+@@ -241,14 +241,26 @@ int FirstStageMain(int argc, char** argv) {
      // should be done in rc files.
      // Mount staging areas for devices managed by vold
      // See storage config details at http://source.android.com/devices/storage/
@@ -30,18 +22,26 @@ index 1b5bdb4..1a9036e 100644
 -                    "mode=0755,uid=0,gid=1000"));
 +
 +    // Disabled for Halium, mounted by LXC config
-+    //CHECKCALL(mount("tmpfs", "/mnt", "tmpfs", MS_NOEXEC | MS_NOSUID | MS_NODEV,
-+    //                "mode=0755,uid=0,gid=1000"));
++    if (is_recovery) {
++        CHECKCALL(mount("tmpfs", "/mnt", "tmpfs", MS_NOEXEC | MS_NOSUID | MS_NODEV,
++                        "mode=0755,uid=0,gid=1000"));
++    }
      // /mnt/vendor is used to mount vendor-specific partitions that can not be
      // part of the vendor partition, e.g. because they are mounted read-write.
 -    CHECKCALL(mkdir("/mnt/vendor", 0755));
-+    //CHECKCALL(mkdir("/mnt/vendor", 0755));
-+    mkdir("/mnt/vendor", 0755);
++    if (is_recovery) {
++        CHECKCALL(mkdir("/mnt/vendor", 0755));
++    } else {
++        mkdir("/mnt/vendor", 0755);
++    }
      // /mnt/product is used to mount product-specific partitions that can not be
      // part of the product partition, e.g. because they are mounted read-write.
 -    CHECKCALL(mkdir("/mnt/product", 0755));
-+    //CHECKCALL(mkdir("/mnt/product", 0755));
-+    mkdir("/mnt/product", 0755);
++    if (is_recovery) {
++        CHECKCALL(mkdir("/mnt/product", 0755));
++    } else {
++        mkdir("/mnt/product", 0755);
++   }
  
      // /debug_ramdisk is used to preserve additional files from the debug ramdisk
      CHECKCALL(mount("tmpfs", "/debug_ramdisk", "tmpfs", MS_NOEXEC | MS_NOSUID | MS_NODEV,


### PR DESCRIPTION
This pull request forward-ports the patches from #24 and adds on top another change that prevents the /apex tmpfs from being mounted in normal mode.

This is currently only compile-tested, except for the /apex change which has been tested at runtime.