### PR TITLE
treewide: Build enablement on macOS

### DIFF
--- a/build/make/0002-build_image-Use-GNU-coreutils-on-macOS.patch
+++ b/build/make/0002-build_image-Use-GNU-coreutils-on-macOS.patch
@@ -1,0 +1,32 @@
+From 8d752b27d6341cd908fa37412783ab53317115e0 Mon Sep 17 00:00:00 2001
+From: Alfred Neumayer <dev.beidl@gmail.com>
+Date: Thu, 12 May 2022 22:00:58 +0200
+Subject: [PATCH] build_image: Use GNU coreutils on macOS
+
+Get the size of the to-be-imaged system directory using 'gdu'.
+
+Change-Id: Ib0ceded2b2fae846ef2e7428fd35eda495fc5c7c
+---
+ tools/releasetools/build_image.py | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/tools/releasetools/build_image.py b/tools/releasetools/build_image.py
+index d8a65d2..597112b 100755
+--- a/tools/releasetools/build_image.py
++++ b/tools/releasetools/build_image.py
+@@ -57,7 +57,11 @@ def GetDiskUsage(path):
+   Returns:
+     The number of bytes based on a 1K block_size.
+   """
+-  cmd = ["du", "-b", "-k", "-s", path]
++  kernel = os.uname()[0]
++  if kernel is "Linux":
++    cmd = ["du", "-b", "-k", "-s", path]
++  else:
++    cmd = ["gdu", "-b", "-k", "-s", path]
+   output = common.RunAndCheckOutput(cmd, verbose=False)
+   return int(output.split()[0]) * 1024
+ 
+-- 
+2.32.0 (Apple Git-132)
+

--- a/build/soong/0001-darwin_host-Add-current-and-future-macOS-SDKs.patch
+++ b/build/soong/0001-darwin_host-Add-current-and-future-macOS-SDKs.patch
@@ -1,0 +1,35 @@
+From a025a235687cce2d61d3f9c4ea17b3918b5da063 Mon Sep 17 00:00:00 2001
+From: Alfred Neumayer <dev.beidl@gmail.com>
+Date: Thu, 12 May 2022 22:04:35 +0200
+Subject: [PATCH] darwin_host: Add current and future macOS SDKs
+
+Allows building Halium with recent Xcode.
+
+Change-Id: Idd7c0915c863be3b1a94a1dfb6e06b3e8942086f
+---
+ cc/config/x86_darwin_host.go | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/cc/config/x86_darwin_host.go b/cc/config/x86_darwin_host.go
+index 2f2b515..dee03d4 100644
+--- a/cc/config/x86_darwin_host.go
++++ b/cc/config/x86_darwin_host.go
+@@ -65,6 +65,15 @@ var (
+ 		"10.14",
+ 		"10.15",
+ 		"11.0",
++		"12.1",
++		"12.2",
++		"12.3",
++		"12.4",
++		"13.0",
++		"13.1",
++		"13.2",
++		"13.3",
++		"13.4",
+ 	}
+ 
+ 	darwinAvailableLibraries = append(
+-- 
+2.32.0 (Apple Git-132)
+

--- a/external/python/cpython2/0001-getpath-Always-use-uint32_t-for-nsexeclength.patch
+++ b/external/python/cpython2/0001-getpath-Always-use-uint32_t-for-nsexeclength.patch
@@ -1,0 +1,33 @@
+From 3ea3b2ce6d3a16cd23229872f89a3349279e0624 Mon Sep 17 00:00:00 2001
+From: Alfred Neumayer <dev.beidl@gmail.com>
+Date: Thu, 12 May 2022 22:06:17 +0200
+Subject: [PATCH] getpath: Always use uint32_t for nsexeclength
+
+Fixes building on recent macOS.
+
+Change-Id: I2640db17c9dc5bbf705588b5938620bb6c1e8eea
+---
+ Modules/getpath.c | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/Modules/getpath.c b/Modules/getpath.c
+index 27f3381..1e0162e 100644
+--- a/Modules/getpath.c
++++ b/Modules/getpath.c
+@@ -386,13 +386,8 @@ calculate_path(void)
+     NSModule pythonModule;
+ #endif
+ #ifdef __APPLE__
+-#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_4
+     uint32_t nsexeclength = MAXPATHLEN;
+-#else
+-    unsigned long nsexeclength = MAXPATHLEN;
+-#endif
+ #endif
+-
+         /* If there is no slash in the argv0 path, then we have to
+          * assume python is on the user's $PATH, since there's no
+          * other way to find a directory to start the search from.  If
+-- 
+2.32.0 (Apple Git-132)
+

--- a/external/selinux/0001-libselinux-Avoid-compiling-sestatus.c-on-macOS.patch
+++ b/external/selinux/0001-libselinux-Avoid-compiling-sestatus.c-on-macOS.patch
@@ -1,0 +1,35 @@
+From a9e79602efabfd678dd9a397f4a6af67580aea4a Mon Sep 17 00:00:00 2001
+From: Alfred Neumayer <dev.beidl@gmail.com>
+Date: Thu, 12 May 2022 22:08:42 +0200
+Subject: [PATCH] libselinux: Avoid compiling sestatus.c on macOS
+
+It's not of any use on the build machine regardless of OS.
+
+Change-Id: I7e32c6cccfa7c3b9972a13511aa24262c7362fff
+---
+ libselinux/Android.bp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libselinux/Android.bp b/libselinux/Android.bp
+index 268fc74..6833cba 100644
+--- a/libselinux/Android.bp
++++ b/libselinux/Android.bp
+@@ -29,7 +29,6 @@ cc_defaults {
+         "src/label.c",
+         "src/label_support.c",
+         "src/matchpathcon.c",
+-        "src/sestatus.c",
+         "src/setrans_client.c",
+         "src/sha1.c",
+     ],
+@@ -71,6 +70,7 @@ cc_defaults {
+                 "src/policyvers.c",
+                 "src/procattr.c",
+                 "src/reject_unknown.c",
++                "src/sestatus.c",
+                 "src/setenforce.c",
+                 "src/setfilecon.c",
+                 "src/stringrep.c",
+-- 
+2.32.0 (Apple Git-132)
+

--- a/external/v8/0001-blueprints-Allow-building-on-both-Linux-and-macOS.patch
+++ b/external/v8/0001-blueprints-Allow-building-on-both-Linux-and-macOS.patch
@@ -1,0 +1,72 @@
+From 85255b502becdfc6ad433afff44f6c0929ebc1eb Mon Sep 17 00:00:00 2001
+From: Alfred Neumayer <dev.beidl@gmail.com>
+Date: Thu, 12 May 2022 22:10:40 +0200
+Subject: [PATCH] blueprints: Allow building on both Linux and macOS
+
+The host portion of v8 needs to be able to distinguish
+between platform code of macOS and Linux, so do just that.
+
+Change-Id: I69a9ca2fb213ee2e23297d2b282a05670e82579b
+---
+ Android.bp         | 12 ++++++++++--
+ Android.libbase.bp |  9 ++++++++-
+ 2 files changed, 18 insertions(+), 3 deletions(-)
+
+diff --git a/Android.bp b/Android.bp
+index 3cec564..b7d9751 100644
+--- a/Android.bp
++++ b/Android.bp
+@@ -174,7 +174,11 @@ cc_defaults {
+ cc_binary_host {
+     name: "v8_bytecode_builtins_list_generator",
+     defaults: ["v8_defaults"],
+-    host_ldlibs: ["-lrt"],
++    target: {
++        linux: {
++            host_ldlibs: ["-lrt"],
++        },
++    },
+     srcs: [
+         "src/builtins/generate-bytecodes-builtins-list.cc",
+         "src/interpreter/bytecode-operands.cc",
+@@ -202,7 +206,11 @@ cc_binary_host {
+         "-fexceptions",
+         "-frtti",
+     ],
+-    host_ldlibs: ["-lrt"],
++    target: {
++        linux: {
++            host_ldlibs: ["-lrt"],
++        },
++    },
+     srcs: [
+         "src/torque/cc-generator.cc",
+         "src/torque/cfg.cc",
+diff --git a/Android.libbase.bp b/Android.libbase.bp
+index 63de80e..cbabdbc 100644
+--- a/Android.libbase.bp
++++ b/Android.libbase.bp
+@@ -36,12 +36,19 @@ cc_library_static {
+                 "src/base/platform/platform-linux.cc",
+             ],
+         },
+-        host: {
++        linux_glibc: {
+             srcs: [
+                 "src/base/debug/stack_trace_posix.cc",
+                 "src/base/platform/platform-linux.cc",
+             ],
+             cflags: ["-UANDROID"],
+         },
++        darwin: {
++            srcs: [
++                "src/base/debug/stack_trace_posix.cc",
++                "src/base/platform/platform-macos.cc",
++            ],
++            cflags: ["-UANDROID"],
++        },
+     },
+ }
+-- 
+2.32.0 (Apple Git-132)
+

--- a/system/core/0016-base-cmsg-Read-PAGESIZE-from-sysconf-if-not-defined.patch
+++ b/system/core/0016-base-cmsg-Read-PAGESIZE-from-sysconf-if-not-defined.patch
@@ -1,0 +1,30 @@
+From 0a7e695ccf36666285fd0249400d8a09abd3e414 Mon Sep 17 00:00:00 2001
+From: Alfred Neumayer <dev.beidl@gmail.com>
+Date: Thu, 12 May 2022 22:14:00 +0200
+Subject: [PATCH] base/cmsg: Read PAGESIZE from sysconf if not defined
+
+As is the case on macOS.
+
+Change-Id: I399c338905651f36efd9089dd1c8728362821b52
+---
+ base/cmsg.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/base/cmsg.cpp b/base/cmsg.cpp
+index 42866f8..0dca7fe 100644
+--- a/base/cmsg.cpp
++++ b/base/cmsg.cpp
+@@ -26,6 +26,10 @@
+ 
+ #include <android-base/logging.h>
+ 
++#ifndef PAGE_SIZE
++#define PAGE_SIZE (size_t)(sysconf(_SC_PAGESIZE))
++#endif
++
+ namespace android {
+ namespace base {
+ 
+-- 
+2.32.0 (Apple Git-132)
+


### PR DESCRIPTION
This patchset allows building various components on both Linux
and macOS, especially those required by the host build environment.