### PR TITLE
prebuilts: Restore bootimage build support on macOS

### DIFF
--- a/prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9/0001-bin-Use-env-to-find-the-Python-interpreter.patch
+++ b/prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9/0001-bin-Use-env-to-find-the-Python-interpreter.patch
@@ -1,0 +1,26 @@
+From 928c6d247e81ea1de64a407d06f797f33450b061 Mon Sep 17 00:00:00 2001
+From: Alfred Neumayer <dev.beidl@gmail.com>
+Date: Sat, 28 May 2022 23:04:31 +0200
+Subject: [PATCH] bin: Use env to find the Python interpreter
+
+Restore support on macOS to build kernels,
+since python2 has been removed from the install.
+
+Change-Id: I42aa41f43c6a7e52f1a40872224799320a140993
+---
+ bin/aarch64-linux-android-gcc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bin/aarch64-linux-android-gcc b/bin/aarch64-linux-android-gcc
+index 54944a2..b65b3eb 100755
+--- a/bin/aarch64-linux-android-gcc
++++ b/bin/aarch64-linux-android-gcc
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python
+ 
+ import os
+ import sys
+-- 
+2.32.1 (Apple Git-133)
+

--- a/prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9/0001-bin-Use-env-to-find-the-Python-interpreter.patch
+++ b/prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9/0001-bin-Use-env-to-find-the-Python-interpreter.patch
@@ -1,0 +1,37 @@
+From becedc0b1c4d83ca6b8b6448193b44a7ac85591e Mon Sep 17 00:00:00 2001
+From: Alfred Neumayer <dev.beidl@gmail.com>
+Date: Sat, 28 May 2022 23:06:33 +0200
+Subject: [PATCH] bin: Use env to find the Python interpreter
+
+Restore support on macOS to build kernels,
+since python2 has been removed from the install.
+
+Change-Id: Ie52dbf9d6b9b8152208948155e42b69f44f89748
+---
+ arm-linux-androideabi/bin/as  | 2 +-
+ bin/arm-linux-androideabi-gcc | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/arm-linux-androideabi/bin/as b/arm-linux-androideabi/bin/as
+index 3c8c5f1..c8f5e07 100755
+--- a/arm-linux-androideabi/bin/as
++++ b/arm-linux-androideabi/bin/as
+@@ -1,4 +1,4 @@
+-#! /usr/bin/python
++#! /usr/bin/env python
+ 
+ from sys import argv
+ from subprocess import check_call
+diff --git a/bin/arm-linux-androideabi-gcc b/bin/arm-linux-androideabi-gcc
+index 54944a2..b65b3eb 100755
+--- a/bin/arm-linux-androideabi-gcc
++++ b/bin/arm-linux-androideabi-gcc
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python
+ 
+ import os
+ import sys
+-- 
+2.32.1 (Apple Git-133)
+


### PR DESCRIPTION
Python 2 has been removed from macOS, so attempt to find a
local installation using /usr/bin/env instead of bailing out.