### PR TITLE
(halium) system/core: Source properties from prop.halium

### DIFF
--- a/system/core/0050-halium-init-Source-properties-from-system-etc-prop.h.patch
+++ b/system/core/0050-halium-init-Source-properties-from-system-etc-prop.h.patch
@@ -1,0 +1,27 @@
+From 600e9f0289de03dc0cc882286bcc62f95832fed9 Mon Sep 17 00:00:00 2001
+From: Alfred Neumayer <dev.beidl@gmail.com>
+Date: Fri, 8 Jul 2022 13:06:36 +0200
+Subject: [PATCH] (halium) init: Source properties from /system/etc/halium.prop
+
+This allows overriding non-readonly properties on top of stock vendors.
+
+Change-Id: I899dae12f06fd8cb90d3b48f67862cb8d8b94400
+---
+ init/property_service.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/init/property_service.cpp b/init/property_service.cpp
+index 823743e..ffb3b0e 100644
+--- a/init/property_service.cpp
++++ b/init/property_service.cpp
+@@ -830,6 +830,7 @@ void load_system_props() {
+     load_properties_from_file("/odm/build.prop", NULL);
+     load_properties_from_file("/vendor/build.prop", NULL);
+     load_properties_from_file("/factory/factory.prop", "ro.*");
++    load_properties_from_file("/system/etc/halium.prop", NULL);
+ 
+     // Update with vendor-specific property runtime overrides
+     vendor_load_properties();
+-- 
+2.32.1 (Apple Git-133)
+


### PR DESCRIPTION
Devices with stock vendor partitions might want to override certain properties
after vendor properties have been sourced. This is the case for the Pixel 3a
where vendor defines CCodec to be used, whereas OMX would be preferred due to
better reliability and better integration into the existing stack.