### PR TITLE
(halium) healthd: Shut down using sys.powerctl in charger mode (#49)

### DIFF
--- a/system/core/0015-halium-healthd-Shut-down-using-sys.powerctl-in-charg.patch
+++ b/system/core/0015-halium-healthd-Shut-down-using-sys.powerctl-in-charg.patch
@@ -1,0 +1,39 @@
+From 93cd4007e42393d06121eb32b31678b7dd8e2b94 Mon Sep 17 00:00:00 2001
+From: Alfred Neumayer <dev.beidl@gmail.com>
+Date: Tue, 29 Mar 2022 21:52:24 +0200
+Subject: [PATCH] (halium) healthd: Shut down using sys.powerctl in charger
+ mode
+
+Since Halium runs in a container, it is not properly guaranteed to
+handle reboots properly. Turns out that on the Pixel 3a it spams
+the kernel log with following messages:
+
+ init: Failed to initialize property area
+
+This might be because the filesystem is from the old instance.
+
+Since init is running and is able to exit cleanly, let's just
+trigger that. The host side will notice the shutdown and cause
+a proper reboot, so it's done by the ultimate authority anyway.
+
+Change-Id: Ia43aaa40e528416810414feb0c4a6dce4f9d548d
+---
+ healthd/healthd_mode_charger.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/healthd/healthd_mode_charger.cpp b/healthd/healthd_mode_charger.cpp
+index 0e5aa4f..e00a77b 100644
+--- a/healthd/healthd_mode_charger.cpp
++++ b/healthd/healthd_mode_charger.cpp
+@@ -473,7 +473,7 @@ static void process_key(charger* charger, int code, int64_t now) {
+                 } else {
+                     if (charger->batt_anim->cur_level >= charger->boot_min_cap) {
+                         LOGW("[%" PRId64 "] rebooting\n", now);
+-                        reboot(RB_AUTOBOOT);
++                        property_set("sys.powerctl", "shutdown");
+                     } else {
+                         LOGV("[%" PRId64
+                              "] ignore power-button press, battery level "
+-- 
+2.25.1
+


### PR DESCRIPTION
Since Halium runs in a container, it is not properly guaranteed to
handle reboots properly. Turns out that on the Pixel 3a it spams
the kernel log with following messages:

 init: Failed to initialize property area

This might be because the filesystem is from the old instance.

Since init is running and is able to exit cleanly, let's just
trigger that. The host side will notice the shutdown and cause
a proper reboot, so it's done by the ultimate authority anyway.