### PR TITLE
(halium) build/make: Include libui_compat_layer

### DIFF
--- a/build/make/0003-halium-add-basic-Halium-build-configuration-based-on.patch
+++ b/build/make/0003-halium-add-basic-Halium-build-configuration-based-on.patch
@@ -1,4 +1,4 @@
-From eac97d5bd6323f49408109d59f7aa7d2f7f40499 Mon Sep 17 00:00:00 2001
+From cdc0e20808edd95d1a6165c77a9c64b1909a5119 Mon Sep 17 00:00:00 2001
 From: NeKit <nekit1000@gmail.com>
 Date: Sun, 9 Feb 2020 18:35:53 +0100
 Subject: [PATCH 4/5] (halium) add basic Halium build configuration based on
@@ -6,16 +6,16 @@ Subject: [PATCH 4/5] (halium) add basic Halium build configuration based on
 
 Change-Id: I7ce0e771a5bdd0a94bd43af35bbfff3edc75dfd1
 ---
- target/product/halium.mk | 42 ++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 42 insertions(+)
+ target/product/halium.mk | 43 ++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 43 insertions(+)
  create mode 100644 target/product/halium.mk
 
 diff --git a/target/product/halium.mk b/target/product/halium.mk
 new file mode 100644
-index 0000000..166bf05
+index 0000000..8f24df8
 --- /dev/null
 +++ b/target/product/halium.mk
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,43 @@
 +# Required Android parts not included by embedded.mk
 +PRODUCT_PACKAGES += \
 +    android.system.net.netd@1.1-service.stub \
@@ -51,6 +51,7 @@ index 0000000..166bf05
 +    libdroidmedia \
 +    libhwc2_compat_layer \
 +    libmedia_compat_layer \
++    libui_compat_layer \
 +    libminisf \
 +    libselinux_stubs \
 +    libubuntu_application_api \
@@ -59,5 +60,5 @@ index 0000000..166bf05
 +
 +$(call inherit-product, $(SRC_TARGET_DIR)/product/embedded.mk)
 -- 
-2.17.1
+2.32.1 (Apple Git-133)
 


### PR DESCRIPTION
Various projects can benefit from the use of libui_compat_layer, the GraphicBuffer wrapper in libhybris.
Most notable examples are haliumqsgcontext & qtubuntu-camera:

- https://github.com/Halium/haliumqsgcontext
- https://gitlab.com/ubports/development/core/qtubuntu-camera/-/merge_requests/24