### PR TITLE
(halium) init: allow createProcessGroup() failure under recovery

### DIFF
--- a/system/core/0020-halium-init-allow-createProcessGroup-failure-under-r.patch
+++ b/system/core/0020-halium-init-allow-createProcessGroup-failure-under-r.patch
@@ -1,0 +1,38 @@
+From 91f16595e76b2703b0502ab83200b96546f53e26 Mon Sep 17 00:00:00 2001
+From: Jami Kettunen <jami.kettunen@protonmail.com>
+Date: Thu, 2 Apr 2026 18:17:55 +0300
+Subject: [PATCH] (halium) init: allow createProcessGroup() failure under
+ recovery
+
+For now this is required for cgroup v1 devices to boot unified UBports
+recovery which realistically covers anything kernel v4.4 and below
+lacking backports, perhaps can be dropped later.
+
+Adapted from https://github.com/LineageOS-UL/android_system_core/commit/0103602
+
+Change-Id: I616da0bfc2fe57a23e5ae034e84516cab634abd8
+---
+ init/service.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/init/service.cpp b/init/service.cpp
+index 38521a955..9e35a46f5 100644
+--- a/init/service.cpp
++++ b/init/service.cpp
+@@ -709,12 +709,16 @@ Result<void> Service::Start() {
+                          limit_percent_ != -1 || !limit_property_.empty();
+         errno = -createProcessGroup(uid(), pid_, use_memcg);
+         if (errno != 0) {
++#if RECOVERY
++            PLOG(ERROR) << "createProcessGroup(" << uid() << ", " << pid_ <<  ") failed for service '" << name_ << "'";
++#else  // RECOVERY
+             Result<void> result = cgroups_activated.Write(kActivatingCgroupsFailed);
+             if (!result.ok()) {
+                 return Error() << "Sending notification failed: " << result.error();
+             }
+             return Error() << "createProcessGroup(" << uid() << ", " << pid_ << ", " << use_memcg
+                            << ") failed for service '" << name_ << "': " << strerror(errno);
++#endif  // RECOVERY
+         }
+ 
+         // When the blkio controller is mounted in the v1 hierarchy, NormalIoPriority is


### PR DESCRIPTION
Contributes to enabling the broader "legacy" device roll-out of [unified UBports recovery](https://gitlab.com/ubports/porting/community-ports/halium-generic-adaptation-build-tools/-/merge_requests/70)

Above tested as now booting on original Volla Phone (`yggdrasil`) without any noticed side-effects on Volla Phone Plinius (`ansuz`):
```
yggdrasil:/ # uname -r
4.4.146+
yggdrasil:/ # getprop ro.system.build.version.release
14
yggdrasil:/ # dmesg | grep createProcessGroup
[    2.396091] init: createProcessGroup(0, 287) failed for service 'ueventd': No such file or directory
[    2.400925] init: createProcessGroup(0, 288) failed for service 'setup_usb': No such file or directory
[    2.691209] init: createProcessGroup(0, 300) failed for service 'vgscan': No such file or directory
[    2.697000] init: createProcessGroup(2000, 301) failed for service 'console': No such file or directory
[    2.715689] init: createProcessGroup(0, 302) failed for service 'setup_fake_cache': No such file or directory
[    2.801777] init: createProcessGroup(0, 311) failed for service 'charger': No such file or directory
[    2.805836] init: createProcessGroup(0, 312) failed for service 'recovery': No such file or directory
[    3.012375] init: createProcessGroup(0, 319) failed for service 'adbd': No such file or directory
[    8.026386] init: createProcessGroup(0, 321) failed for service 'adbd': No such file or directory
```